### PR TITLE
Rework of ConfigModelPublication messages and fix to AppKeyGet

### DIFF
--- a/bluetooth_mesh/messages/config.py
+++ b/bluetooth_mesh/messages/config.py
@@ -6,7 +6,7 @@ from construct import (
     GreedyBytes, GreedyRange,
     BitsInteger, Int24ul, Int16ul, Int8ul, Flag, Bytes,
     ExprValidator, ValidationError,
-    this, len_, obj_, Padding
+    this, len_, obj_, Padding, Computed
 )
 
 from .util import (
@@ -650,11 +650,13 @@ ConfigModelPublicationGet = Struct(
 ConfigModelPublicationSet = Struct(
     "element_address" / UnicastAddress,
     "publish_address" / NotVirtualLabel,
-    "embedded" / Reversed(BitStruct(
+    *EmbeddedBitStruct(
+        "_",
         "RFU" / BitsInteger(3),
         "credential_flag" / PublishFriendshipCredentialsFlagAdapter,
-        "app_key_index" / BitsInteger(12)
-    )),
+        "app_key_index" / BitsInteger(12),
+        reversed=True
+    ),
     "TTL" / TTL,
     "publish_period" / PublishPeriod,
     "retransmit" / Retransmit,
@@ -669,11 +671,13 @@ ConfigModelPublicationStatus = Struct(
 ConfigModelPublicationVASet = Struct(
     "element_address" / UnicastAddress,
     "publish_address" / Bytes(16),
-    "embedded" / Reversed(BitStruct(
+    *EmbeddedBitStruct(
+        "_",
         "RFU" / BitsInteger(3),
         "credential_flag" / PublishFriendshipCredentialsFlagAdapter,
-        "app_key_index" / BitsInteger(12)
-    )),
+        "app_key_index" / BitsInteger(12),
+        reversed=True
+    ),
     "TTL" / TTL,
     "publish_period" / PublishPeriod,
     "retransmit" / Retransmit,
@@ -773,7 +777,7 @@ ConfigAppKeyStatus = Struct(
 )
 
 ConfigAppKeyGet = Struct(
-    *AppKeyIndex
+    *NetKeyIndex
 )
 
 ConfigAppKeyList = Struct(

--- a/bluetooth_mesh/messages/config.py
+++ b/bluetooth_mesh/messages/config.py
@@ -6,7 +6,7 @@ from construct import (
     GreedyBytes, GreedyRange,
     BitsInteger, Int24ul, Int16ul, Int8ul, Flag, Bytes,
     ExprValidator, ValidationError,
-    this, len_, obj_, Padding, Computed
+    this, len_, obj_, Padding
 )
 
 from .util import (
@@ -518,6 +518,7 @@ def SingleKeyIndex(name):
         name / BitsInteger(12),
         reversed=True
     )
+
 
 NetAndAppKeyIndex = DoubleKeyIndex("net_key_index", "app_key_index")
 

--- a/bluetooth_mesh/messages/test/test_config.py
+++ b/bluetooth_mesh/messages/test/test_config.py
@@ -525,11 +525,9 @@ valid = [
         {
             "element_address": 0x0201,
             "publish_address": 0x0001,
-            "embedded": {
-                "RFU": 0,
-                "credential_flag": PublishFriendshipCredentialsFlag.FRIENDSHIP_SECURITY,
-                "app_key_index": 0xabc,
-            },
+            "RFU": 0,
+            "credential_flag": PublishFriendshipCredentialsFlag.FRIENDSHIP_SECURITY,
+            "app_key_index": 0xabc,
             "TTL": 0x7F,
             "publish_period": {
                 "step_resolution": PublishPeriodStepResolution.RESOLUTION_10_MIN,
@@ -552,11 +550,9 @@ valid = [
         {
             "element_address": 0x0102,
             "publish_address": 0x0304,
-            "embedded": {
-                "RFU": 0,
-                "credential_flag": PublishFriendshipCredentialsFlag.MASTER_SECURITY,
-                "app_key_index": 5,
-            },
+            "RFU": 0,
+            "credential_flag": PublishFriendshipCredentialsFlag.MASTER_SECURITY,
+            "app_key_index": 5,
             "TTL": 6,
             "publish_period": {
                 "step_resolution": PublishPeriodStepResolution.RESOLUTION_100_MS,
@@ -579,11 +575,9 @@ valid = [
             "status": StatusCode.INVALID_MODEL,
             "element_address": 0x0102,
             "publish_address": 0x0304,
-            "embedded": {
-                "RFU": 0,
-                "credential_flag": PublishFriendshipCredentialsFlag.MASTER_SECURITY,
-                "app_key_index": 5,
-            },
+            "RFU": 0,
+            "credential_flag": PublishFriendshipCredentialsFlag.MASTER_SECURITY,
+            "app_key_index": 5,
             "TTL": 6,
             "publish_period": {
                 "step_resolution": PublishPeriodStepResolution.RESOLUTION_100_MS,
@@ -658,7 +652,7 @@ valid = [
         ConfigAppKeyGet,
         bytes.fromhex('0200'),
         {
-            "app_key_index": 2,
+            "net_key_index": 2,
         },
         id="ConfigAppKeyGet"
     ),

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.md", "r") as f:
 
 setup(
     name='bluetooth-mesh',
-    version='0.1.15',
+    version='0.1.16',
     author='Michał Lowas-Rzechonek',
     author_email='michal.lowas-rzechonek@silvair.com',
     description=(


### PR DESCRIPTION
This patch reworks construct for ConfigModelPublicationSet messages to take advantage of EmbeddedBitStruct and flatten params structure. 
Also it fixes ConfigAppKeyGet message.