### PR TITLE
models: Increase 'send_interval' for SAR'ed messages

### DIFF
--- a/bluetooth_mesh/models/base.py
+++ b/bluetooth_mesh/models/base.py
@@ -351,7 +351,7 @@ class Model:
         request: Callable[[], Awaitable[None]],
         status: asyncio.Future,
         *,
-        send_interval: float = 0.1,
+        send_interval: float = 0.2,
         timeout: float = 2.0,
     ) -> Any:
         """


### PR DESCRIPTION
This patch increases 'send_interval' for SAR'ed messages. Too short 'send_interval' causes abort SAR transactions and in result Status messages doesn't arrive within given timeout.