### PR TITLE
Fix add_publication and improve RetransmitAdapter

### DIFF
--- a/bluetooth_mesh/messages/config.py
+++ b/bluetooth_mesh/messages/config.py
@@ -581,8 +581,15 @@ class RetransmitAdapter(Adapter):
     def _encode(self, obj, context, path):
         if obj["count"] > 7:
             raise AttributeError("Retransmission count maximum value is 7")
-        if not 0 < obj["interval"] <= 0x20*self.interval or obj["interval"] % self.interval:
-            raise AttributeError("Interval value must be in range of {min} and {max} with increment of {min}".format(min=self.interval, max=0x20*self.interval))
+        if (
+            not 0 < obj["interval"] <= 0x20 * self.interval
+            or obj["interval"] % self.interval
+        ):
+            raise AttributeError(
+                "Interval value must be in range of {min} and {max} with increment of {min}".format(
+                    min=self.interval, max=0x20 * self.interval
+                )
+            )
         return dict(
             count=obj["count"],
             interval_steps=int(round((obj["interval"] / self.interval) - 1)),

--- a/bluetooth_mesh/messages/config.py
+++ b/bluetooth_mesh/messages/config.py
@@ -579,6 +579,10 @@ class RetransmitAdapter(Adapter):
         )
 
     def _encode(self, obj, context, path):
+        if obj["count"] > 7:
+            raise AttributeError("Retransmission count maximum value is 7")
+        if not 0 < obj["interval"] <= 0x20*self.interval or obj["interval"] % self.interval:
+            raise AttributeError("Interval value must be in range of {min} and {max} with increment of {min}".format(min=self.interval, max=0x20*self.interval))
         return dict(
             count=obj["count"],
             interval_steps=int(round((obj["interval"] / self.interval) - 1)),

--- a/bluetooth_mesh/messages/test/test_config.py
+++ b/bluetooth_mesh/messages/test/test_config.py
@@ -1036,3 +1036,60 @@ def test_parse_config_message():
         opcode=ConfigOpcode.APPKEY_ADD,
         params=dict(app_key_index=1, net_key_index=1, app_key=key,),
     )
+
+
+invalid_retr = [
+    # fmt: off
+    pytest.param(
+        NetworkRetransmit,
+        bytes.fromhex('F8'),
+        {
+            "count": 0x00,
+            "interval": 0
+        },
+        id="interval = 0"
+    ),
+    pytest.param(
+        NetworkRetransmit,
+        bytes.fromhex('F8'),
+        {
+            "count": 0x00,
+            "interval": 5
+        },
+        id="interval = 5"
+    ),
+    pytest.param(
+        NetworkRetransmit,
+        bytes.fromhex('F8'),
+        {
+            "count": 0x00,
+            "interval": 330
+        },
+        id="interval too high"
+    ),
+    pytest.param(
+        PublishRetransmit,
+        bytes.fromhex('F8'),
+        {
+            "count": 0x00,
+            "interval": 1700
+        },
+        id="interval too high"
+    ),
+    pytest.param(
+        PublishRetransmit,
+        bytes.fromhex('F8'),
+        {
+            "count": 0x08,
+            "interval": 700
+        },
+        id="count too high"
+    ),
+]
+
+
+@pytest.mark.parametrize("message,encoded,decoded", invalid_retr)
+def test_build(message, encoded, decoded):
+    _decoded = deepcopy(decoded)
+    with pytest.raises(AttributeError):
+        message.build(obj=_decoded)

--- a/bluetooth_mesh/models/models.py
+++ b/bluetooth_mesh/models/models.py
@@ -649,7 +649,8 @@ class ConfigClient(Model):
         TTL: int = 8,
         publish_step_resolution: int = 2,
         publish_number_of_steps: int = 6,  # 60seconds
-        retransmit: int = 2,
+        retransmit_count: int = 0,
+        retransmit_interval: int = 50,
     ) -> ModelSubscriptionStatus:
 
         status = self.expect_dev(
@@ -668,7 +669,7 @@ class ConfigClient(Model):
                     step_resolution=publish_step_resolution,
                     number_of_steps=publish_number_of_steps,
                 ),
-                retransmit=dict(interval_steps=0, count=retransmit),
+                retransmit=dict(count=retransmit_count, interval=retransmit_interval),
                 model=self._get_model_id(model),
             ),
         )
@@ -689,7 +690,7 @@ class ConfigClient(Model):
                     step_resolution=publish_step_resolution,
                     number_of_steps=publish_number_of_steps,
                 ),
-                retransmit=dict(interval_steps=0, count=retransmit),
+                retransmit=dict(count=retransmit_count, interval=retransmit_interval),
                 model=self._get_model_id(model),
             ),
         )

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands = python setup.py test
 [testenv:black]
 skip_install = true
 deps = black
-commands = black
+commands = black bluetooth_mesh
 
 [testenv:isort]
 skip_install = true


### PR DESCRIPTION
This patch fixes add_publication method in ConfigClient model.

This should fix: Config Client add_publication: no subconstruct matched #34