### PR TITLE
Application: better name for subnet_keys property

### DIFF
--- a/bluetooth_mesh/application.py
+++ b/bluetooth_mesh/application.py
@@ -163,9 +163,9 @@ class NetworkKeyMixin:
         raise NotImplementedError("Getting primary network key should be overridden!")
 
     @property
-    def net_keys(self) -> List[Tuple[int, NetworkKey]]:
+    def subnet_keys(self) -> List[Tuple[int, NetworkKey]]:
         """
-        Indexes and keyes of the subnets.
+        Indexes and keys of the subnets.
         """
         raise NotImplementedError("Getting subnet network keys should be overridden!")
 

--- a/bluetooth_mesh/apps/meshcli.py
+++ b/bluetooth_mesh/apps/meshcli.py
@@ -968,7 +968,7 @@ class MeshCommandLine(*application_mixins, Application):
         self._tid = 0
 
     async def add_keys(self):
-        for index, key in self.net_keys:
+        for index, key in self.subnet_keys:
             await self.add_net_key(index, key)
 
         for index, bound, key in self.app_keys:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.rst", "r") as f:
 # fmt: off
 setup(
     name='bluetooth-mesh',
-    version='0.2.5',
+    version='0.2.6',
     author_email='michal.lowas-rzechonek@silvair.com',
     description=(
         'Bluetooth mesh for Python'


### PR DESCRIPTION
`net_keys` suggests that it would return all known network keys, but the property was designed to provide an easy access to subnet keys only.