### PR TITLE
Connect: enable not passing address

### DIFF
--- a/bluetooth_mesh/application.py
+++ b/bluetooth_mesh/application.py
@@ -30,7 +30,18 @@ import logging
 from enum import Enum
 from functools import lru_cache
 from os import urandom
-from typing import Any, Awaitable, Dict, List, Mapping, Optional, Tuple, Type, Union, Callable
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 from uuid import UUID, uuid5
 
 import construct
@@ -558,7 +569,9 @@ class Application(
             elif isinstance(addr, int):
                 mesh_address = addr
             else:
-                raise TypeError("Address not given as a value or an acceptable callback.")
+                raise TypeError(
+                    "Address not given as a value or an acceptable callback."
+                )
             await self.import_node(addr=mesh_address, iv_index=iv_index)
             configuration = await self.attach()
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.rst", "r") as f:
 # fmt: off
 setup(
     name='bluetooth-mesh',
-    version='0.2.8',
+    version='0.2.9',
     author_email='michal.lowas-rzechonek@silvair.com',
     description=(
         'Bluetooth mesh for Python'

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands = isort -rc bluetooth_mesh
 extras = tools
 deps =
     isort[pyproject]
-    pylint
+    pylint<2.5
     pytest
 commands = pylint --exit-zero bluetooth_mesh
 


### PR DESCRIPTION
If an application is sure it's `attach()` will succeed, it doesn't
have to supply `addr` straight away. It may rather postpone getting
address until it's actually needed: when application UUID changes or
when it's launched with a different `meshd` instance.

We have a case like that in gateway: it should be possible to launch
the application without internet access. Since we get our address from
Commissioning, we should be able to do so only when necessary.