### PR TITLE
DBusMixin: context manager returns self

### DIFF
--- a/bluetooth_mesh/application.py
+++ b/bluetooth_mesh/application.py
@@ -232,15 +232,16 @@ class DeviceKeyMixin:
 
 class DBusMixin:
     DBUS_SERVICE = None
+    logger: logging.Logger
 
-    def _name_owner_changed(self, name, old_owner, new_owner):
+    def _name_owner_changed(self, name, old_owner, new_owner) -> None:
         if name != self.DBUS_SERVICE.NAME:
             return
 
         self.logger.error("Disconnected from %s (%s)", name, old_owner)
         self.dbus_disconnected(old_owner)
 
-    async def dbus_connect(self):
+    async def dbus_connect(self) -> None:
         message_bus = dbus_next.aio.MessageBus(bus_type=dbus_next.BusType.SYSTEM)
         self.logger.debug("Connecting to D-Bus")
         self.bus = await message_bus.connect()
@@ -257,20 +258,20 @@ class DBusMixin:
         self.dbus_interface.on_name_owner_changed(self._name_owner_changed)
         await self.dbus_connected(owner)
 
-    async def dbus_disconnect(self):
+    async def dbus_disconnect(self) -> None:
         self.dbus_interface.off_name_owner_changed(self._name_owner_changed)
         self.bus.disconnect()
 
-    async def dbus_connected(self, owner):
+    async def dbus_connected(self, owner) -> None:
         pass
 
-    def dbus_disconnected(self, owner):
+    def dbus_disconnected(self, owner) -> Any:
         self.loop.stop()
 
     async def __aenter__(self):
         return await self.dbus_connect()
 
-    async def __aexit__(self, exc_type, exc, tb):
+    async def __aexit__(self, exc_type, exc, tb) -> Any:
         return await self.dbus_disconnect()
 
 

--- a/bluetooth_mesh/application.py
+++ b/bluetooth_mesh/application.py
@@ -268,8 +268,9 @@ class DBusMixin:
     def dbus_disconnected(self, owner) -> Any:
         self.loop.stop()
 
-    async def __aenter__(self):
-        return await self.dbus_connect()
+    async def __aenter__(self) -> "DBusMixin":
+        await self.dbus_connect()
+        return self
 
     async def __aexit__(self, exc_type, exc, tb) -> Any:
         return await self.dbus_disconnect()

--- a/docs/skeleton.py
+++ b/docs/skeleton.py
@@ -1,6 +1,7 @@
 import asyncio
-
+import secrets
 from contextlib import suppress
+
 from docopt import docopt
 
 from bluetooth_mesh.application import Application, Element
@@ -62,14 +63,15 @@ class SampleApplication(Application):
         assert status == StatusCode.SUCCESS, \
             'Cannot bind application key: %s' % status
 
-    async def run(self):
-        await self.connect(iv_index=5)
-        await self.configure()
+    async def run(self, addr):
+        async with self:
+            await self.connect(addr=addr, iv_index=5)
+            await self.configure()
 
-        client = self.elements[0][HealthClient]
+            client = self.elements[0][HealthClient]
 
-        for node in [0x0001, 0x0002, 0x0003]:
-            await client.attention(node, app_index=0, attention=3)
+            for node in [0x0001, 0x0002, 0x0003]:
+                await client.attention(node, app_index=0, attention=3)
 
 
 def main():
@@ -92,10 +94,11 @@ def main():
     addr = int(addr, 16 if addr.startswith('0x') else 10)
 
     loop = asyncio.get_event_loop()
-    app = SampleApplication(addr, loop)
+    app = SampleApplication(loop)
 
     with suppress(KeyboardInterrupt):
-        loop.run_until_complete(app.run())
+        loop.run_until_complete(app.run(addr))
+
 
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.rst", "r") as f:
 # fmt: off
 setup(
     name='bluetooth-mesh',
-    version='0.2.10',
+    version='0.2.11',
     author_email='michal.lowas-rzechonek@silvair.com',
     description=(
         'Bluetooth mesh for Python'


### PR DESCRIPTION
This enables usages like:
```python
async with MyMeshdApp(loop) as app:
    await app.connect(address)
```
I've also updated `skeleton.py` example to current API usage.

Fixes #44