### PR TITLE
Skip Sar message segments that were ack-ed

### DIFF
--- a/bluetooth_mesh/test/test_mesh.py
+++ b/bluetooth_mesh/test/test_mesh.py
@@ -90,6 +90,12 @@ def proxy_use_whitelist_message():
     return ProxyConfigMessage(src=0x0001, opcode=0x00, payload=parameters)
 
 
+@fixture
+def app_sar_message():
+    payload = bytes.fromhex("510c00000000020b0c1f00efcdab071b1c")
+    return AccessMessage(src=1234, dst=4321, ttl=1, payload=payload)
+
+
 def test_network_beacon_received(net_key):
     beacon, auth = SecureNetworkBeacon.unpack(
         bytes.fromhex("003ecaff672f673370123456788ea261582f364f6f")
@@ -266,6 +272,22 @@ def test_application_pack_to_network_pdu(
     )
 
     assert network_pdu.hex() == "6848cba437860e5673728a627fb938535508e21a6baf57"
+
+
+def test_application_pack_to_network_pdu_skip_segments(
+    app_sar_message: AccessMessage, app_key: ApplicationKey, net_key: NetworkKey,
+):
+    network_message = NetworkMessage(app_sar_message)
+    ((seq, network_pdu),) = network_message.pack(
+        app_key,
+        net_key,
+        seq=0x000007,
+        iv_index=0x12345678,
+        transport_seq=0x000008,
+        skip_segments=[0],
+    )
+
+    assert network_pdu.hex() == "689353e01b0a211f82734ad0c7c92081616414e0f8b7e7048c7e"
 
 
 def test_application_unpack_from_network_pdu(

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.rst", "r") as f:
 # fmt: off
 setup(
     name='bluetooth-mesh',
-    version='0.2.11',
+    version='0.2.12',
     author_email='michal.lowas-rzechonek@silvair.com',
     description=(
         'Bluetooth mesh for Python'

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     packages=find_packages(exclude=('test*', )),
     python_requires='>=3.6.0,<3.8.0',
     setup_requires=[
-        'pytest-runner>=4.2',
+        'pytest-runner==4.2',
     ],
     install_requires=[
         'bitstring>=3.1.5',
@@ -51,10 +51,10 @@ setup(
         'marshmallow>=3.0.1,<4.0',
     ],
     tests_require=[
-        'asynctest>=0.12.3',
-        'coveralls>=1.11.`',
+        'asynctest==0.12.3',
+        'coveralls==2.0.0',
         'pytest==5.0.0',
-        'pytest-asyncio>=0.10.0',
+        'pytest-asyncio==0.10.0',
         'pytest-cov>=2.8.1',
     ],
     extras_require=dict(

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     tests_require=[
         'asynctest>=0.12.3',
         'coveralls>=1.11.`',
-        'pytest==5.4.0',
+        'pytest==5.0.0',
         'pytest-asyncio>=0.10.0',
         'pytest-cov>=2.8.1',
     ],


### PR DESCRIPTION
This patch adds option to skip Access Message segments that were ack-ed for before encrypting them into Network PDUs. 