### PR TITLE
application: Accept corotuines in Application.connect(addr=...)

### DIFF
--- a/bluetooth_mesh/application.py
+++ b/bluetooth_mesh/application.py
@@ -551,7 +551,7 @@ class Application(
 
     async def connect(
         self,
-        addr: Union[int, Callable[[], int], Awaitable[int]],
+        addr: Union[int, Callable[[], int], Callable[[], Awaitable[int]]],
         iv_index: int = 0,
         **kwargs,
     ) -> Mapping[int, Dict[Tuple[int, int], Dict[str, Tuple[Any, int]]]]:
@@ -570,12 +570,15 @@ class Application(
             configuration = await self.attach(**kwargs)
         except (ValueError, dbus_next.errors.DBusError) as ex:
             self.logger.error("Attach failed: %s, trying to import node", ex)
-            if isinstance(addr, Awaitable):
-                mesh_address = await addr
+
+            if isinstance(addr, int):
+                mesh_address = addr
             elif isinstance(addr, Callable):
                 mesh_address = addr()
-            elif isinstance(addr, int):
-                mesh_address = addr
+
+            if isinstance(addr, Awaitable):
+                mesh_address = await addr
+
             else:
                 raise TypeError(
                     "Address not given as a value or an acceptable callback."

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.rst", "r") as f:
 # fmt: off
 setup(
     name='bluetooth-mesh',
-    version='0.2.29',
+    version='0.2.30',
     author_email='michal.lowas-rzechonek@silvair.com',
     description=(
         'Bluetooth mesh for Python'


### PR DESCRIPTION
This allows us to fix `  /usr/lib/python3.7/json/decoder.py:353: RuntimeWarning: coroutine 'get_main_app_mesh_address' was never awaited` warning on the application side, if we pass an awaitable (*not* a corotuine) to `connect` which doesn't need to obtain the address.