### PR TITLE
meshcli: Allow running multiple commands in a row

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.rst", "r") as f:
 # fmt: off
 setup(
     name='bluetooth-mesh',
-    version='0.2.35',
+    version='0.2.36',
     author_email='michal.lowas-rzechonek@silvair.com',
     description=(
         'Bluetooth mesh for Python'


### PR DESCRIPTION
```
$ source env.office && time meshcli -l $OFFICE_STATS_PLATFORM_LOGIN -p $OFFICE_STATS_PLATFORM_PASSWORD -n "Silvair Office" "uptime -g Lambda" "light -g Red"
2020-11-30 14:58:31 MeshCommandLine                          INFO           mixins.py:106  Logging into PlatformEnvironment.PREPROD/silvair: michal.lowas-rzechonek@silvair.com
2020-11-30 14:58:32 MeshCommandLine                          INFO           mixins.py:127  Selected project: Silvair Office
2020-11-30 14:58:32 MeshCommandLine                          INFO           mixins.py:138  Obtained address for application 7af112955371598b87f1a0b2ab893910: 0282
2020-11-30 14:58:33 MeshCommandLine                          INFO      application.py:258  Connecting to org.bluez.mesh
2020-11-30 14:58:33 MeshCommandLine                          INFO      application.py:528  Registering application
2020-11-30 14:58:33 MeshCommandLine                          INFO      application.py:802  Attach b3234f9d43942afe (socket_pair=False, socket_path=/home/khorne/.config/meshcli/7af11295-5371-598b-87f1-a0b2ab893910.socket)
2020-11-30 14:58:33 MeshCommandLine.Element0.DebugClient     INFO             base.py:102  Update config of (310, 22): <ModelConfig bindings=[0, 1, 2], subs=[]>
2020-11-30 14:58:33 MeshCommandLine.Element0.HealthClient    INFO             base.py:102  Update config of (None, 3): <ModelConfig bindings=[0, 1, 2], subs=[]>
2020-11-30 14:58:33 MeshCommandLine                          INFO      application.py:841  Attached to node /org/bluez/mesh/node7af112955371598b87f1a0b2ab893910, address: 0282, configuration: defaultdict(<class 'dict'>, {0: {(310, 22): {'bindings': [0, 1, 2]}, (None, 3): {'bindings': [0, 1, 2]}}})
2020-11-30 14:58:33 MeshCommandLine                          INFO          meshcli.py:1329  Loaded network Network(name=unnamed, uuid=5ebedf88-2419-45b3-954c-38c011dee5b5), 214 nodes
2020-11-30 14:58:33 MeshCommandLine                          INFO          meshcli.py:1341  Running command: uptime -g Lambda
2020-11-30 14:58:34 MeshCommandLine                          INFO          meshcli.py:1341  Running command: light -g Red
Lambda | !SilvairOffice FnF 7894: 28 days, 5:38:19
Lambda | !SilvairOffice FnF 4840: 28 days, 5:34:29
Lambda | !SilvairOffice FnF 0517: 28 days, 5:35:44
Lambda | !SilvairOffice FnF e542: 28 days, 5:34:31
Lambda | !SilvairOffice FnF b6ab: 28 days, 5:34:02
Lambda | !SilvairOffice FnF fd40: 28 days, 5:31:41
Lambda | !Silvair MicroGateway dc65: 11 days, 2:09:46
!SilvairOffice DALI EvalBoard 8a00: lightness 46340, temperature None
!SilvairOffice DALI EvalBoard 1998: lightness 46340, temperature None
!SilvairOffice DALI EvalBoard f24a: lightness 46340, temperature None
!SilvairOffice DALI EvalBoard b956: lightness 46340, temperature None
!SilvairOffice DALI EvalBoard 652a: lightness 46340, temperature None
!SilvairOffice UART Client c32b: lightness None, temperature None
```