### PR TITLE
Refactor attach sequence

### DIFF
--- a/bluetooth_mesh/apps/meshcli.py
+++ b/bluetooth_mesh/apps/meshcli.py
@@ -615,12 +615,12 @@ class BindAppKeyCommand(ModelCommandMixin, NodeSelectionCommandMixin, Command):
 
         element = int(arguments["--element"]) if arguments["--element"] is not None else 0
         key_index = int(arguments["--keyindex"]) if arguments["--keyindex"] is not None else 0
+
         for dst in destinations:
             element_address = dst + element
 
             results = await model.bind_app_key(
-                dst, 0, element_address, key_index, model=getattr(models, arguments["--model"])
-            )
+                dst, 0, element_address, key_index, model=getattr(models, arguments["--model"]))
 
             node = application.network.get_node(address=dst)
             if results is None:
@@ -1534,7 +1534,7 @@ class MeshCommandLine(*application_mixins, Application):
 
         for node in self.network.nodes:
             # don't overwrite my own key
-            if node.address in range(self.addr, self.addr + len(self.ELEMENTS)):
+            if node.address in range(self.address, self.address + len(self.ELEMENTS)):
                 continue
 
             await self.management_interface.import_remote_node(
@@ -1551,13 +1551,15 @@ class MeshCommandLine(*application_mixins, Application):
             await time_client.bind(index)
 
     async def run(self, commands):
-        addr, self.network = await self.get_network()
+        self.address, self.network = await self.get_network()
 
         async with self:
-            await self._run(addr, commands)
+            await self._run(commands)
 
-    async def _run(self, addr, commands):
-        await self.connect(addr, socket_path=f"{self.config_dir}/{self.uuid}.socket")
+    async def _run(self, commands):
+        await self.connect(
+            self.token_ring.token, socket_path=f"{self.config_dir}/{self.uuid}.socket"
+        )
         await self.add_keys()
         self.logger.info(
             "Loaded network %s, %d nodes", self.network, len(self.network.nodes)

--- a/bluetooth_mesh/test/test_application.py
+++ b/bluetooth_mesh/test/test_application.py
@@ -1,23 +1,28 @@
 import logging
+from uuid import UUID
 
+from functools import lru_cache
 import dbus_next.errors
+import dbus_next.signature
 import pytest
 
-from bluetooth_mesh.application import Application
+from bluetooth_mesh.application import Application, Element
 from bluetooth_mesh.crypto import NetworkKey
 
 pytestmark = [pytest.mark.asyncio]
 
 
 class Node:
-    def __init__(self, path, configuration):
+    def __init__(self, path, token, address):
         self.path = path
-        self.configuration = configuration
+        self.configuration = []
+        self.address = address
+        self.token = token
 
 
 @pytest.fixture
 def node():
-    return Node("/org/bluez/mesh/node1234", {})
+    return Node("/org/bluez/mesh/node3342c6c574ed4145888ce1d978a1f145", 0x4321, 0x100)
 
 
 @pytest.fixture
@@ -39,25 +44,45 @@ def dbus(monkeypatch, node, application):
         async def call_get_name_owner(self, service_name):
             pass
 
+    class MockNodeInterface(MockInterface):
+        NODE = node
+
+        async def get_addresses(self):
+            return [self.NODE.address]
+
     class MockNetworkInterface(MockInterface):
+        NODE = node
+
         async def call_attach(self, app_root, token):
-            if node is None:
+            if self.NODE is None:
                 raise dbus_next.errors.DBusError(
                     "org.bluez.mesh.Failure", "Node doesn't exist"
                 )
 
-            return node.path, node.configuration
+            if self.NODE.token != token:
+                raise dbus_next.errors.DBusError(
+                    "org.bluez.mesh.Failure", "Invalid token"
+                )
+
+            return self.NODE.path, self.NODE.configuration
 
         async def call_import(
             self, app_root, uuid, dev_key, net_key, net_index, flags, iv_index, unicast
         ):
-            nonlocal node
-            node = Node("/org/bluez/mesh/node1234", {})
-            application.join_complete(1234)
+            path = f"/org/bluez/mesh/node{uuid.hex()}"
 
-    class MockNodeInterface(MockInterface):
-        async def get_addresses(self):
-            return [1]
+            if MockMessageBus.SERVICE_OBJECTS.get(("org.bluez.mesh", path)):
+                raise dbus_next.errors.DBusError(
+                    "org.bluez.mesh.Failure", "Node exists"
+                )
+
+            MockMessageBus.SERVICE_OBJECTS[
+                ("org.bluez.mesh", path)
+            ] = MockNodeProxyObject
+            MockNodeInterface.NODE = MockNetworkInterface.NODE = Node(
+                path, 0x5678, unicast
+            )
+            application.join_complete(0x5678)
 
     class MockManagementInterface(MockInterface):
         async def call_import_remote_node(self, primary, count, device_key):
@@ -96,7 +121,6 @@ def dbus(monkeypatch, node, application):
         SERVICE_OBJECTS = {
             ("org.freedesktop.DBus", "/org/freedesktop/DBus"): MockDbusProxyObject,
             ("org.bluez.mesh", "/org/bluez/mesh"): MockNetworkProxyObject,
-            ("org.bluez.mesh", "/org/bluez/mesh/node1234"): MockNodeProxyObject,
         }
 
         def __init__(self, bus_type):
@@ -124,12 +148,35 @@ def dbus(monkeypatch, node, application):
                 service_name, object_path, introspection
             )
 
+    if node:
+        MockMessageBus.SERVICE_OBJECTS[
+            ("org.bluez.mesh", node.path)
+        ] = MockNodeProxyObject
+
     monkeypatch.setattr("dbus_next.aio.MessageBus", MockMessageBus)
 
 
 @pytest.fixture
 def application(event_loop):
+    class MockElement(Element):
+        LOCATION = 0
+
     class MockApplication(Application):
+        ELEMENTS = {0: MockElement}
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.address = 0x200
+            self.__uuid = UUID("3a1f9d4659b74b009dfd32cf9e758b7a")
+
+        @property
+        def uuid(self) -> UUID:
+            return self.__uuid
+
+        @uuid.setter
+        def uuid(self, value):
+            self.__uuid = value
+
         @property
         def primary_net_key(self):
             return 0, NetworkKey(bytes.fromhex("b37e0124a48a406bd2b092e82bea6aed"))
@@ -137,42 +184,76 @@ def application(event_loop):
     return MockApplication(event_loop)
 
 
-async def test_attach(application, dbus):
+async def test_attach_bad_token(application, dbus, node):
     async with application:
-        await application.attach()
+        with pytest.raises(dbus_next.errors.DBusError, match="Invalid token"):
+            await application.attach(node.token + 1)
+
+
+async def test_attach_good_token(application, dbus, node):
+    async with application:
+        await application.attach(node.token)
+        assert (
+            application.node_interface._interface.proxy_object.object_path == node.path
+        )
 
 
 @pytest.mark.parametrize("node", [None])
-class TestConnect:
-    async def test_addr_value(self, application, dbus):
+class TestImportOnConnect:
+    async def test_import(self, application, dbus):
         async with application:
-            await application.connect(addr=1)
+            await application.connect()
 
-    async def test_addr_bad_value(self, application, dbus):
-        async with application:
-            with pytest.raises(TypeError, match="Address not given"):
-                await application.connect(addr="foo")
+            assert (
+                application.node_interface._interface.proxy_object.object_path
+                == f"/org/bluez/mesh/node{application.uuid.hex}"
+            )
+            assert application.address == 0x200
 
-    async def test_addr_callable(self, application, dbus):
-        async with application:
-            await application.connect(addr=lambda: 1)
-
-    async def test_addr_bad_callable(self, application, dbus):
-        async with application:
-            with pytest.raises(TypeError, match="Address not given"):
-                await application.connect(addr=lambda: "foo")
-
-    async def test_addr_coroutine(self, application, dbus):
-        async def addr():
-            return 1
+    async def test_missing_address(self, application, dbus):
+        application.address = None
 
         async with application:
-            await application.connect(addr=addr)
+            with pytest.raises(
+                AttributeError, match="Application didn't provide an address"
+            ):
+                await application.connect()
 
-    async def test_addr_bad_coroutine(self, application, dbus):
-        async def addr():
-            return "foo"
+
+class TestAttachOnConnect:
+    async def test_read_address_after_attach(self, application, dbus, node):
+        application.address = None
+        application.token_ring.token = node.token
 
         async with application:
-            with pytest.raises(TypeError, match="Address not given"):
-                await application.connect(addr=addr)
+            await application.connect()
+
+            assert (
+                application.node_interface._interface.proxy_object.object_path
+                == node.path
+            )
+            assert application.address == node.address
+
+            with pytest.raises(AttributeError, match="Can't set address"):
+                application.address = 5
+
+    async def test_import_new_on_attach_with_bad_token(self, application, dbus, node):
+        application.token_ring.token = node.token + 1
+
+        async with application:
+            await application.connect()
+
+            assert (
+                application.node_interface._interface.proxy_object.object_path
+                == f"/org/bluez/mesh/node{application.uuid.hex}"
+            )
+            assert application.address == 0x200
+
+    async def test_import_existing_with_bad_token(self, application, dbus, node):
+        application.token_ring.token = node.token + 1
+        _, uuid = node.path.split("/node")
+        application.uuid = UUID(uuid)
+
+        async with application:
+            with pytest.raises(dbus_next.errors.DBusError, match="Node exists"):
+                await application.connect()

--- a/bluetooth_mesh/tokenring.py
+++ b/bluetooth_mesh/tokenring.py
@@ -41,26 +41,25 @@ class TokenRing:
 
     def __init__(self, uuid):
         self.uuid = str(uuid)
-        self.schema = StoredNodeSchema()
-        self.data = {}
+        self.data = self._load()
 
+    def _load(self):
         os.makedirs(self.path, exist_ok=True)
         for path in [self.path, os.path.expanduser(self.LEGACY_PATH)]:
             try:
                 with open(os.path.join(path, self.uuid), "r") as tokenfile:
                     r = tokenfile.read()
                     try:
-                        self.data = self.schema.loads(r)
-                        return
+                        return StoredNodeSchema().loads(r)
                     except (JSONDecodeError, ValidationError, EOFError):
-                        self.data = dict(token=int(r, 16), acl={}, network={})
+                        return dict(token=int(r, 16), acl={}, network={})
 
             except FileNotFoundError:
-                self.data = dict(token=0, acl={}, network={})
+                return dict(token=0, acl={}, network={})
 
     def _save(self):
         with open(os.path.join(self.path, self.uuid), "w") as tokenfile:
-            tokenfile.write(self.schema.dumps(self.data))
+            tokenfile.write(StoredNodeSchema().dumps(self.data))
 
     @property
     def token(self):

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.rst", "r") as f:
 # fmt: off
 setup(
     name='bluetooth-mesh',
-    version='0.4.5',
+    version='0.5.0',
     author_email='michal.lowas-rzechonek@silvair.com',
     description=(
         'Bluetooth mesh for Python'


### PR DESCRIPTION
This is needed to take advantage of https://github.com/homersoft/python-platforms-clients/pull/154, where we can store the token (and our dev key!) in the cloud during node creation (see `join_callback`)

**This is a breaking change**