### PR TITLE
Fix content type of long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'Bluetooth mesh for Python'
     ),
     long_description=long_description,
-    long_description_content_type="text/markdown",
+    long_description_content_type="text/x-rst",
     url='http://github.com/silvairgit/python-bluetooth-mesh',
     packages=find_packages(exclude=('test*', )),
     python_requires='>=3.6.0,<3.8.0',


### PR DESCRIPTION
Invalid content type caused wrong rendering of long description on pypi.org