### PR TITLE
Type introspection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
   - python: 3.7
     env: TOX_ENV=pylint
 install:
-- pip install tox keyring==21.4.0
+- pip install tox keyring==21.4.0 pkgconfig
 script:
 - tox -e $TOX_ENV
 after_success:

--- a/bluetooth_mesh/apps/meshcli.py
+++ b/bluetooth_mesh/apps/meshcli.py
@@ -413,7 +413,7 @@ class TtlCommand(ConfigCommand):
     PARAMETER = "default_ttl"
 
     def format(self, data):
-        return data["TTL"]
+        return data["ttl"]
 
 
 class RelayCommand(ConfigCommand):
@@ -491,7 +491,7 @@ class PublicationCommand(ModelCommandMixin, NodeSelectionCommandMixin, Command):
                     element_address=address + element_index,
                     publication_address=int(arguments["--address"], 16),
                     app_key_index=int(arguments["--key-index"]),
-                    TTL=int(arguments["--ttl"]),
+                    ttl=int(arguments["--ttl"]),
                     publish_step_resolution=resolution,
                     publish_number_of_steps=steps,
                     retransmit_count=int(arguments["--count"]),
@@ -1047,17 +1047,17 @@ class CompositionDataCommand(ModelCommandMixin, NodeSelectionCommandMixin, Comma
 
             yield "{}: CID {}, PID {}, VID {}, CRPL {}, Features {:016b}".format(
                 node.name,
-                composition["CID"],
-                composition["PID"],
-                composition["VID"],
-                composition["CRPL"],
+                composition["cid"],
+                composition["pid"],
+                composition["vid"],
+                composition["crpl"],
                 composition["features"],
             )
 
             for i, ele in enumerate(composition["elements"]):
                 yield "\tElement {}, location: {}".format(i, ele["location"])
                 yield "\t\t   SIG Models: " + ", ".join(
-                    "{:04x}".format(mod["model_id"]) for mod in ele["SIG_models"]
+                    "{:04x}".format(mod["model_id"]) for mod in ele["sig_models"]
                 )
                 yield "\t\tVendor Models: " + ", ".join(
                     "{:04x}:{:04x}".format(mod["vendor_id"], mod["model_id"])

--- a/bluetooth_mesh/messages/__init__.py
+++ b/bluetooth_mesh/messages/__init__.py
@@ -69,15 +69,17 @@ class _AccessMessage(Construct):
         TimeOpcode: TimeMessage,
     }
 
+    OPCODE = Opcode()
+
     def __init__(self):
         super().__init__()
         self._opcodes = {}
         for opcode_class, message in self.OPCODES.items():
             for opcode in opcode_class._value2member_map_.keys():
-                self._opcodes[opcode] = opcode_class(opcode), message
+                self._opcodes[opcode] = opcode_class(opcode), message.compile()
 
     def _parse(self, stream, context, path):
-        opcode = Opcode()._parse(stream, context, path)
+        opcode = self.OPCODE._parse(stream, context, path)
 
         try:
             opcode, message = self._opcodes[opcode]

--- a/bluetooth_mesh/messages/capnproto.py
+++ b/bluetooth_mesh/messages/capnproto.py
@@ -1,0 +1,314 @@
+#!python
+
+import importlib
+import math
+import pkgutil
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from enum import IntEnum
+from itertools import chain, count
+from typing import Dict
+
+from construct import (
+    Adapter,
+    Array,
+    BitsInteger,
+    Bytes,
+    BytesInteger,
+    Const,
+    Construct,
+    Default,
+    FixedSized,
+    Flag,
+    FormatField,
+    GreedyBytes,
+    GreedyRange,
+    NullStripped,
+    Padded,
+    Pass,
+    Rebuild,
+    Renamed,
+    Restreamed,
+    Select,
+    StopIf,
+    Struct,
+    Switch,
+    Transformed,
+)
+
+from bluetooth_mesh.messages import AccessMessage
+
+
+class VariableNames:
+    def __init__(self, root_name):
+        self.names = {}
+        self._load_names(root_name)
+
+    def _load_names(self, root_name):
+        root_module = importlib.import_module(root_name)
+
+        for loader, name, is_pkg in pkgutil.walk_packages(root_module.__path__):
+            module_name = f"{root_name}.{name}"
+            module = importlib.import_module(module_name)
+            self.names.update({id(v): k for k, v in module.__dict__.items()})
+
+            if is_pkg:
+                self._load_names(module_name)
+
+    def __getitem__(self, item):
+        return self.names.get(id(item))
+
+
+names = VariableNames("bluetooth_mesh.messages")
+
+
+def convert(
+    con,
+    visitor,
+    field_name=None,
+    struct_name=None,
+    many=False,
+    message_name=None,
+):
+    struct_name = struct_name or names[con] or f"{message_name}Params"
+
+    if field_name and field_name.startswith("_"):
+        return
+
+    if isinstance(con, Struct):
+        visitor.enter_struct(field_name, struct_name, many=many)
+
+        for subcon in con.subcons:
+            convert(subcon, visitor, message_name=message_name)
+
+        visitor.exit()
+
+    elif isinstance(con, Switch):
+        if many:
+            visitor.enter_struct(field_name, struct_name, many=many)
+            visitor.enter_union(None)
+        else:
+            visitor.enter_union(field_name)
+
+        for key, subcon in con.cases.items():
+            if isinstance(key, IntEnum):
+                key = type(key)(key).name
+
+            convert(subcon, visitor, field_name=key, message_name=message_name)
+
+        visitor.exit()
+
+        if many:
+            visitor.exit()
+
+    elif isinstance(con, Select):
+        if many:
+            visitor.enter_struct(field_name, struct_name, many=many)
+            visitor.enter_union(None)
+        else:
+            visitor.enter_union(field_name)
+
+        for subcon in con.subcons:
+            convert(
+                subcon,
+                visitor,
+                message_name=message_name,
+            )
+
+        visitor.exit()
+
+        if many:
+            visitor.exit()
+
+    elif isinstance(con, Renamed):
+        convert(
+            con.subcon,
+            visitor,
+            field_name=con.name,
+            message_name=message_name,
+            many=many,
+        )
+
+    elif isinstance(con, (GreedyRange, Array)):
+        convert(
+            con.subcon,
+            visitor,
+            field_name=field_name,
+            # struct_name=struct_name,
+            many=True,
+            message_name=message_name,
+        )
+
+    elif con is Pass:
+        return
+
+    elif isinstance(con, StopIf):
+        return
+
+    elif isinstance(con, Construct):
+        subcon = getattr(con, "_subcon", getattr(con, "subcon", None))
+        if subcon is None:
+            visitor.field(con, field_name, struct_name, many=many)
+            return
+
+        convert(
+            subcon,
+            visitor,
+            field_name=field_name,
+            struct_name=struct_name,
+            message_name=message_name,
+            many=many,
+        )
+
+    else:
+        raise TypeError
+
+
+class Visitor:
+    def __init__(self, struct_name):
+        self.types = {}
+        self.structs = defaultdict(dict)
+
+        struct_fields = self.structs.setdefault(struct_name, {})
+        self.stack = [(struct_name, struct_fields)]
+        self._has_union = False
+
+    @property
+    def current(self):
+        field_name, struct_fields = self.stack[-1]
+        return struct_fields
+
+    @staticmethod
+    def _camelcase(field_name):
+        if field_name is None:
+            return None
+
+        head, *tail = str(field_name).lower().replace(" ", "_").split("_")
+        return "".join([head, *(i.title() for i in tail)])
+
+    @staticmethod
+    def make_type(con):
+        FORMAT_FIELD_TYPES = dict(
+            c="UInt8",
+            b="Int8",
+            B="UInt8",
+            h="Int16",
+            H="UInt16",
+            i="Int32",
+            I="UInt32",
+            l="Int32",
+            L="UInt32",
+            q="Int64",
+            Q="UInt64",
+            f="Float32",
+            d="Float64",
+        )
+
+        if isinstance(con, Bytes) or con is GreedyBytes:
+            return f"Data"
+
+        elif isinstance(con, FormatField):
+            return FORMAT_FIELD_TYPES[con.fmtstr[1:]]
+
+        elif isinstance(con, BitsInteger):
+            width = max(2 ** math.ceil(math.log2(con.length)), 8)
+            return f"Int{width}" if con.signed else f"UInt{width}"
+
+        elif isinstance(con, BytesInteger):
+            width = max(2 ** math.ceil(math.log2(con.length * 8)), 8)
+            return f"Int{width}" if con.signed else f"UInt{width}"
+
+        elif con is Flag:
+            return "Bool"
+
+    def enter_struct(self, field_name="", struct_name="", many=False):
+        field_name = self._camelcase(field_name)
+
+        self.current[field_name] = f"List({struct_name})" if many else struct_name
+        struct_fields = self.structs.setdefault(struct_name, {})
+        self.stack.append((struct_name, struct_fields))
+
+    def enter_union(self, field_name=""):
+        self._has_union = True
+        field_name = self._camelcase(field_name)
+
+        union_fields = self.current.setdefault(field_name, {})
+        self.stack.append((field_name, union_fields))
+
+    def exit(self):
+        if len(self.stack) == 3:
+            if not self._has_union:
+                struct_name, struct_fields = self.stack[-1]
+                self.types[struct_name] = struct_fields
+                self.structs.pop(struct_name)
+
+            self._has_union = False
+
+        self.stack.pop(-1)
+
+    def items(self):
+        return chain(self.types.items(), self.structs.items())
+
+    def field(self, con, field_name, struct_name, many=False):
+        field_name = self._camelcase(field_name)
+
+        type_name = self.make_type(con) or struct_name
+
+        if many:
+            type_name = f"List({type_name})"
+
+        self.current[field_name] = type_name
+
+
+def generate(protocol_id, file=sys.stdout):
+    visitor = Visitor("AccessMessage")
+
+    for opcode, message in AccessMessage.OPCODES.items():
+        convert(message, visitor, field_name=names[opcode], message_name=names[message])
+
+    visitor.structs["AccessMessage"] = {"opcode": "UInt32", None: {}}
+
+    for opcode, message in AccessMessage.OPCODES.items():
+        message_fields = visitor.structs.pop(
+            names[message], visitor.types.get(names[message])
+        )
+        if (
+            message_fields
+            and None in message_fields
+            and isinstance(message_fields[None], dict)
+        ):
+            visitor.structs["AccessMessage"][None].update(message_fields[None])
+
+    print(f"@0x{protocol_id:x};", file=file)
+    print("", file=file)
+
+    def describe(struct_fields, field_tag=None, level=1):
+        field_tag = field_tag or count()
+
+        for field_name, field_type in struct_fields.items():
+            if isinstance(field_type, dict):
+                if field_name:
+                    print(" " * (level * 4 - 1), f"{field_name} :union {{", file=file)
+                else:
+                    print(" " * (level * 4 - 1), f"union {{", file=file)
+
+                describe(field_type, field_tag, level + 1)
+
+                print(" " * (level * 4 - 1), f"}}", file=file)
+            else:
+                print(
+                    " " * (level * 4 - 1),
+                    f"{field_name} @{next(field_tag)} :{field_type};",
+                    file=file,
+                )
+
+    for struct_name, struct_fields in visitor.items():
+        print(f"struct {struct_name} {{", file=file)
+        describe(struct_fields)
+        print("}", file=file)
+        print("", file=file)
+
+
+if __name__ == "__main__":
+    generate(0xD988DA1AAFBE9E47)

--- a/bluetooth_mesh/messages/config.py
+++ b/bluetooth_mesh/messages/config.py
@@ -721,14 +721,21 @@ ConfigBeaconSet = Struct(
 
 ConfigBeaconStatus = ConfigBeaconSet
 
+class CompositionDataPage(enum.IntEnum):
+    ZERO = 0
+    LAST = 255
+
+CompositionDataPageAdapter = EnumAdapter(Int8ul, CompositionDataPage)
+
 ConfigCompositionDataGet = Struct(
-    "page" / Int8ul,
+    "page" / CompositionDataPageAdapter,
 )
 
 ConfigCompositionData = Switch(
         this.page,
         {
-            0: CompositionData,
+            CompositionDataPage.ZERO: CompositionData,
+            CompositionDataPage.LAST: GreedyBytes,
         },
         default=GreedyBytes
 )

--- a/bluetooth_mesh/messages/config.py
+++ b/bluetooth_mesh/messages/config.py
@@ -569,9 +569,10 @@ Retransmit = BitStruct(
 
 
 class RetransmitAdapter(Adapter):
+    _subcon = Int16ul
+
     def __init__(self, subcon, interval):
         self.interval = interval
-        self.subcon = subcon
         super(RetransmitAdapter, self).__init__(subcon)
 
     def _decode(self, obj, context, path):
@@ -626,6 +627,8 @@ NetKeyIndex = SingleKeyIndex("net_key_index")
 
 
 class KeyIndicesAdapter(Adapter):
+    _subcon = GreedyRange(BitsInteger(12))
+
     def _decode(self, obj, context, path):
         """
         Flatten a list dictionaries into list of items:

--- a/bluetooth_mesh/messages/config.py
+++ b/bluetooth_mesh/messages/config.py
@@ -47,7 +47,7 @@ from construct import (
     this,
 )
 
-from .util import (
+from bluetooth_mesh.messages.util import (
     BitList,
     EmbeddedBitStruct,
     EnumAdapter,

--- a/bluetooth_mesh/messages/config.py
+++ b/bluetooth_mesh/messages/config.py
@@ -41,7 +41,6 @@ from construct import (
     Rebuild,
     Select,
     Struct,
-    Switch,
     len_,
     obj_,
     this,
@@ -56,6 +55,7 @@ from bluetooth_mesh.messages.util import (
     RangeValidator,
     Reversed,
     SwitchStruct,
+    EnumSwitch as Switch
 )
 
 

--- a/bluetooth_mesh/messages/config.py
+++ b/bluetooth_mesh/messages/config.py
@@ -431,8 +431,8 @@ VendorModelId = Struct(
 )
 
 ModelId = Select(
-    VendorModelId,
-    SIGModelId
+    vendor=VendorModelId,
+    sig=SIGModelId
 )
 # fmt: on
 
@@ -725,15 +725,17 @@ ConfigCompositionDataGet = Struct(
     "page" / Int8ul,
 )
 
-ConfigCompositionDataStatus = Struct(
-    "page" / Int8ul,
-    "data" / Switch(
+ConfigCompositionData = Switch(
         this.page,
         {
             0: CompositionData,
         },
         default=GreedyBytes
-    ),
+)
+
+ConfigCompositionDataStatus = Struct(
+    "page" / Int8ul,
+    "data" / ConfigCompositionData,
 )
 
 ConfigDefaultTTLGet = Struct()

--- a/bluetooth_mesh/messages/config.py
+++ b/bluetooth_mesh/messages/config.py
@@ -55,6 +55,7 @@ from bluetooth_mesh.messages.util import (
     Opcode,
     RangeValidator,
     Reversed,
+    SwitchStruct,
 )
 
 
@@ -723,7 +724,8 @@ ConfigBeaconStatus = ConfigBeaconSet
 
 class CompositionDataPage(enum.IntEnum):
     ZERO = 0
-    LAST = 255
+    FIRST = 1
+    TWO_HUNDRED_AND_FIFTY_FIFTH = 255
 
 CompositionDataPageAdapter = EnumAdapter(Int8ul, CompositionDataPage)
 
@@ -732,16 +734,16 @@ ConfigCompositionDataGet = Struct(
 )
 
 ConfigCompositionData = Switch(
-        this.page,
-        {
-            CompositionDataPage.ZERO: CompositionData,
-            CompositionDataPage.LAST: GreedyBytes,
-        },
-        default=GreedyBytes
+    this.page,
+    {
+        CompositionDataPage.ZERO: CompositionData,
+        CompositionDataPage.FIRST: GreedyBytes,
+        CompositionDataPage.TWO_HUNDRED_AND_FIFTY_FIFTH: GreedyBytes,
+    }
 )
 
-ConfigCompositionDataStatus = Struct(
-    "page" / Int8ul,
+ConfigCompositionDataStatus = SwitchStruct(
+    "page" / CompositionDataPageAdapter,
     "data" / ConfigCompositionData,
 )
 
@@ -1118,7 +1120,7 @@ class ConfigOpcode(enum.IntEnum):
 
 
 # fmt: off
-ConfigMessage = Struct(
+ConfigMessage = SwitchStruct(
     "opcode" / Opcode(ConfigOpcode),
     "params" / Switch(
         this.opcode,

--- a/bluetooth_mesh/messages/config.py
+++ b/bluetooth_mesh/messages/config.py
@@ -546,17 +546,17 @@ Int12ul = ExprValidator(
 
 CompositionDataElement = Struct(
     "location" / GATTNamespaceDescriptorAdapter,
-    "SIG_number" / Rebuild(Int8ul, len_(this["SIG_models"])),
+    "sig_number" / Rebuild(Int8ul, len_(this["sig_models"])),
     "vendor_number" / Rebuild(Int8ul, len_(this["vendor_models"])),
-    "SIG_models" / SIGModelId[this["SIG_number"]],
+    "sig_models" / SIGModelId[this["sig_number"]],
     "vendor_models" / VendorModelId[this["vendor_number"]],
 )
 
 CompositionData = Struct(
-    "CID" / Int16ul,
-    "PID" / Int16ul,
-    "VID" / Int16ul,
-    "CRPL" / Int16ul,
+    "cid" / Int16ul,
+    "pid" / Int16ul,
+    "vid" / Int16ul,
+    "crpl" / Int16ul,
     "features" / Int16ul,  # TODO should be parsed
     "elements" / GreedyRange(CompositionDataElement),
 )
@@ -750,7 +750,7 @@ ConfigCompositionDataStatus = SwitchStruct(
 ConfigDefaultTTLGet = Struct()
 
 ConfigDefaultTTLSet = Struct(
-    "TTL" / TTL,
+    "ttl" / TTL,
 )
 
 ConfigDefaultTTLStatus = ConfigDefaultTTLSet
@@ -782,12 +782,12 @@ ConfigModelPublicationSet = Struct(
     "publish_address" / NotVirtualLabel,
     *EmbeddedBitStruct(
         "_",
-        "RFU" / BitsInteger(3),
+        "rfu" / BitsInteger(3),
         "credential_flag" / PublishFriendshipCredentialsFlagAdapter,
         "app_key_index" / BitsInteger(12),
         reversed=True
     ),
-    "TTL" / TTL,
+    "ttl" / TTL,
     "publish_period" / PublishPeriod,
     "retransmit" / PublishRetransmit,
     "model" / ModelId,
@@ -808,7 +808,7 @@ ConfigModelPublicationVASet = Struct(
         "app_key_index" / BitsInteger(12),
         reversed=True
     ),
-    "TTL" / TTL,
+    "ttl" / TTL,
     "publish_period" / PublishPeriod,
     "retransmit" / PublishRetransmit,
     "model" / ModelId,
@@ -962,7 +962,7 @@ ConfigVendorModelAppGet = Struct(
 ConfigVendorModelAppList = Struct(
     "status" / StatusCodeAdapter,
     Embedded(ConfigVendorModelAppGet),
-    "app key indices" / KeyIndices,
+    "app_key_indices" / KeyIndices,
 )
 
 ConfigNodeReset = Struct()
@@ -1002,7 +1002,7 @@ ConfigHeartbeatPublicationSet = Struct(
     "destination" / UnicastUnassignedGroupAddress,
     "count" / LogAdapter(Int8ul, max_value=0x10, infinity=True),
     "period" / LogAdapter(Int8ul, max_value=0x10),
-    "TTL" / TTL,
+    "ttl" / TTL,
     "features" / BitList(2),
     *NetKeyIndex,
 )

--- a/bluetooth_mesh/messages/generic/battery.py
+++ b/bluetooth_mesh/messages/generic/battery.py
@@ -21,14 +21,11 @@
 #
 from enum import IntEnum
 
-from construct import BitsInteger, BitStruct, Int8ul, Int24ul, Struct, Switch, this
+from construct import BitsInteger, BitStruct, Int8ul, Int24ul, Struct, this
 
-from bluetooth_mesh.messages.util import (
-    DefaultCountValidator,
-    EnumAdapter,
-    Opcode,
-    SwitchStruct,
-)
+from bluetooth_mesh.messages.util import DefaultCountValidator, EnumAdapter
+from bluetooth_mesh.messages.util import EnumSwitch as Switch
+from bluetooth_mesh.messages.util import Opcode, SwitchStruct
 
 
 class GenericBatteryOpcode(IntEnum):

--- a/bluetooth_mesh/messages/generic/battery.py
+++ b/bluetooth_mesh/messages/generic/battery.py
@@ -23,7 +23,12 @@ from enum import IntEnum
 
 from construct import BitsInteger, BitStruct, Int8ul, Int24ul, Struct, Switch, this
 
-from bluetooth_mesh.messages.util import DefaultCountValidator, EnumAdapter, Opcode
+from bluetooth_mesh.messages.util import (
+    DefaultCountValidator,
+    EnumAdapter,
+    Opcode,
+    SwitchStruct,
+)
 
 
 class GenericBatteryOpcode(IntEnum):
@@ -80,7 +85,7 @@ GenericBatteryStatus = Struct(
     "flags" / BatteryFlags
 )
 
-GenericBatteryMessage = Struct(
+GenericBatteryMessage = SwitchStruct(
     "opcode" / Opcode(GenericBatteryOpcode),
     "params" / Switch(
         this.opcode,

--- a/bluetooth_mesh/messages/generic/level.py
+++ b/bluetooth_mesh/messages/generic/level.py
@@ -56,8 +56,8 @@ GenericLevelSetOptional = Struct(
 )
 
 GenericLevelSet = Select(
-    GenericLevelSetOptional,
-    GenericLevelSetMinimal
+    optional=GenericLevelSetOptional,
+    minimal=GenericLevelSetMinimal
 )
 
 GenericDeltaSetMinimal = Struct(
@@ -71,8 +71,8 @@ GenericDeltaSetOptional = Struct(
 )
 
 GenericDeltaSet = Select(
-    GenericDeltaSetOptional,
-    GenericDeltaSetMinimal
+    optional=GenericDeltaSetOptional,
+    minimal=GenericDeltaSetMinimal
 )
 
 GenericMoveSetMinimal = Struct(
@@ -86,8 +86,8 @@ GenericMoveSetOptional = Struct(
 )
 
 GenericMoveSet = Select(
-    GenericMoveSetOptional,
-    GenericMoveSetMinimal
+    optional=GenericMoveSetOptional,
+    minimal=GenericMoveSetMinimal
 )
 
 GenericLevelStatusMinimal = Struct(
@@ -101,8 +101,8 @@ GenericLevelStatusOptional = Struct(
 )
 
 GenericLevelStatus = Select(
-    GenericLevelStatusOptional,
-    GenericLevelStatusMinimal
+    optional=GenericLevelStatusOptional,
+    minimal=GenericLevelStatusMinimal
 )
 
 GenericLevelMessage = Struct(

--- a/bluetooth_mesh/messages/generic/level.py
+++ b/bluetooth_mesh/messages/generic/level.py
@@ -28,7 +28,7 @@ from bluetooth_mesh.messages.generics import (
     TransitionTime,
     TransitionTimeAdapter,
 )
-from bluetooth_mesh.messages.util import EnumAdapter, Opcode
+from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct
 
 
 class GenericLevelOpcode(IntEnum):
@@ -105,7 +105,7 @@ GenericLevelStatus = Select(
     minimal=GenericLevelStatusMinimal
 )
 
-GenericLevelMessage = Struct(
+GenericLevelMessage = SwitchStruct(
     "opcode" / Opcode(GenericLevelOpcode),
     "params" / Switch(
         this.opcode,

--- a/bluetooth_mesh/messages/generic/level.py
+++ b/bluetooth_mesh/messages/generic/level.py
@@ -21,14 +21,14 @@
 #
 from enum import IntEnum
 
-from construct import Embedded, Int8ul, Int16sl, Int32sl, Select, Struct, Switch, this
+from construct import Embedded, Int8ul, Int16sl, Int32sl, Struct, Switch, this
 
 from bluetooth_mesh.messages.generics import (
     OptionalSetParameters,
     TransitionTime,
     TransitionTimeAdapter,
 )
-from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct
+from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct, NamedSelect
 
 
 class GenericLevelOpcode(IntEnum):
@@ -55,7 +55,7 @@ GenericLevelSetOptional = Struct(
     Embedded(OptionalSetParameters)
 )
 
-GenericLevelSet = Select(
+GenericLevelSet = NamedSelect(
     optional=GenericLevelSetOptional,
     minimal=GenericLevelSetMinimal
 )
@@ -70,7 +70,7 @@ GenericDeltaSetOptional = Struct(
     Embedded(OptionalSetParameters)
 )
 
-GenericDeltaSet = Select(
+GenericDeltaSet = NamedSelect(
     optional=GenericDeltaSetOptional,
     minimal=GenericDeltaSetMinimal
 )
@@ -85,7 +85,7 @@ GenericMoveSetOptional = Struct(
     Embedded(OptionalSetParameters)
 )
 
-GenericMoveSet = Select(
+GenericMoveSet = NamedSelect(
     optional=GenericMoveSetOptional,
     minimal=GenericMoveSetMinimal
 )
@@ -100,7 +100,7 @@ GenericLevelStatusOptional = Struct(
     "remaining_time" / TransitionTimeAdapter(TransitionTime, allow_unknown=True)
 )
 
-GenericLevelStatus = Select(
+GenericLevelStatus = NamedSelect(
     optional=GenericLevelStatusOptional,
     minimal=GenericLevelStatusMinimal
 )

--- a/bluetooth_mesh/messages/generic/level.py
+++ b/bluetooth_mesh/messages/generic/level.py
@@ -21,14 +21,16 @@
 #
 from enum import IntEnum
 
-from construct import Embedded, Int8ul, Int16sl, Int32sl, Struct, Switch, this
+from construct import Embedded, Int8ul, Int16sl, Int32sl, Struct, this
 
 from bluetooth_mesh.messages.generics import (
     OptionalSetParameters,
     TransitionTime,
     TransitionTimeAdapter,
 )
-from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct, NamedSelect
+from bluetooth_mesh.messages.util import EnumAdapter
+from bluetooth_mesh.messages.util import EnumSwitch as Switch
+from bluetooth_mesh.messages.util import NamedSelect, Opcode, SwitchStruct
 
 
 class GenericLevelOpcode(IntEnum):

--- a/bluetooth_mesh/messages/generic/light/ctl.py
+++ b/bluetooth_mesh/messages/generic/light/ctl.py
@@ -21,7 +21,7 @@
 #
 from enum import IntEnum
 
-from construct import Embedded, Int8ul, Int16ul, Select, Struct, Switch, this
+from construct import Embedded, Int8ul, Int16ul, Struct, Switch, this
 
 from bluetooth_mesh.messages.config import StatusCodeAdapter
 from bluetooth_mesh.messages.generics import (
@@ -29,7 +29,7 @@ from bluetooth_mesh.messages.generics import (
     TransitionTime,
     TransitionTimeAdapter,
 )
-from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct
+from bluetooth_mesh.messages.util import EnumAdapter, NamedSelect, Opcode, SwitchStruct
 
 
 class LightCTLOpcode(IntEnum):
@@ -79,7 +79,7 @@ LightCTLSetOptional = Struct(
     Embedded(OptionalSetParameters)
 )
 
-LightCTLSet = Select(
+LightCTLSet = NamedSelect(
     optional=LightCTLSetOptional,
     minimal=LightCTLSetMinimal
 )
@@ -96,7 +96,7 @@ LightCTLStatusOptional = Struct(
     "remaining_time" / TransitionTimeAdapter(TransitionTime, allow_unknown=True)
 )
 
-LightCTLStatus = Select(
+LightCTLStatus = NamedSelect(
     optional=LightCTLStatusOptional,
     minimal=LightCTLStatusMinimal
 )
@@ -113,7 +113,7 @@ LightCTLTemperatureStatusOptional = Struct(
     "remaining_time" / TransitionTimeAdapter(TransitionTime, allow_unknown=True)
 )
 
-LightCTLTemperatureStatus = Select(
+LightCTLTemperatureStatus = NamedSelect(
     optional=LightCTLTemperatureStatusOptional,
     minimal=LightCTLTemperatureStatusMinimal
 )
@@ -129,7 +129,7 @@ LightCTLTemperatureSetOptional = Struct(
     Embedded(OptionalSetParameters)
 )
 
-LightCTLTemperatureSet = Select(
+LightCTLTemperatureSet = NamedSelect(
     optional=LightCTLTemperatureSetOptional,
     minimal=LightCTLTemperatureSetMinimal
 )

--- a/bluetooth_mesh/messages/generic/light/ctl.py
+++ b/bluetooth_mesh/messages/generic/light/ctl.py
@@ -80,8 +80,8 @@ LightCTLSetOptional = Struct(
 )
 
 LightCTLSet = Select(
-    LightCTLSetOptional,
-    LightCTLSetMinimal
+    optional=LightCTLSetOptional,
+    minimal=LightCTLSetMinimal
 )
 
 LightCTLStatusMinimal = Struct(
@@ -97,8 +97,8 @@ LightCTLStatusOptional = Struct(
 )
 
 LightCTLStatus = Select(
-    LightCTLStatusOptional,
-    LightCTLStatusMinimal
+    optional=LightCTLStatusOptional,
+    minimal=LightCTLStatusMinimal
 )
 
 LightCTLTemperatureStatusMinimal = Struct(
@@ -114,8 +114,8 @@ LightCTLTemperatureStatusOptional = Struct(
 )
 
 LightCTLTemperatureStatus = Select(
-    LightCTLTemperatureStatusOptional,
-    LightCTLTemperatureStatusMinimal
+    optional=LightCTLTemperatureStatusOptional,
+    minimal=LightCTLTemperatureStatusMinimal
 )
 
 LightCTLTemperatureSetMinimal = Struct(
@@ -130,8 +130,8 @@ LightCTLTemperatureSetOptional = Struct(
 )
 
 LightCTLTemperatureSet = Select(
-    LightCTLTemperatureSetOptional,
-    LightCTLTemperatureSetMinimal
+    optional=LightCTLTemperatureSetOptional,
+    minimal=LightCTLTemperatureSetMinimal
 )
 
 LightCTLRange = Struct(

--- a/bluetooth_mesh/messages/generic/light/ctl.py
+++ b/bluetooth_mesh/messages/generic/light/ctl.py
@@ -29,7 +29,7 @@ from bluetooth_mesh.messages.generics import (
     TransitionTime,
     TransitionTimeAdapter,
 )
-from bluetooth_mesh.messages.util import EnumAdapter, Opcode
+from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct
 
 
 class LightCTLOpcode(IntEnum):
@@ -145,7 +145,7 @@ LightCTLRangeStatus = Struct(
 )
 
 
-LightCTLMessage = Struct(
+LightCTLMessage = SwitchStruct(
     "opcode" / Opcode(LightCTLOpcode),
     "params" / Switch(
         this.opcode,
@@ -167,7 +167,7 @@ LightCTLMessage = Struct(
 )
 
 
-LightCTLSetupMessage = Struct(
+LightCTLSetupMessage = SwitchStruct(
     "opcode" / Opcode(LightCTLSetupOpcode),
     "params" / Switch(
         this.opcode,

--- a/bluetooth_mesh/messages/generic/light/lightness.py
+++ b/bluetooth_mesh/messages/generic/light/lightness.py
@@ -29,7 +29,7 @@ from bluetooth_mesh.messages.generics import (
     TransitionTime,
     TransitionTimeAdapter,
 )
-from bluetooth_mesh.messages.util import EnumAdapter, Opcode, OpcodeMessage
+from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct
 
 
 class LightLightnessOpcode(IntEnum):
@@ -109,27 +109,39 @@ LightLightnessSet = Select(
     minimal=LightLightnessSetMinimal
 )
 
-LightLightnessMessage = OpcodeMessage({
-    LightLightnessOpcode.LIGHTNESS_GET: LightLightnessGet,
-    LightLightnessOpcode.LIGHTNESS_SET: LightLightnessSet,
-    LightLightnessOpcode.LIGHTNESS_SET_UNACKNOWLEDGED: LightLightnessSet,
-    LightLightnessOpcode.LIGHTNESS_STATUS: LightLightnessStatus,
-    LightLightnessOpcode.LIGHTNESS_LINEAR_GET: LightLightnessGet,
-    LightLightnessOpcode.LIGHTNESS_LINEAR_SET: LightLightnessSet,
-    LightLightnessOpcode.LIGHTNESS_LINEAR_SET_UNACKNOWLEDGED: LightLightnessSet,
-    LightLightnessOpcode.LIGHTNESS_LINEAR_STATUS: LightLightnessStatus,
-    LightLightnessOpcode.LIGHTNESS_LAST_GET: LightLightnessGet,
-    LightLightnessOpcode.LIGHTNESS_LAST_STATUS: LightLightnessDefault,
-    LightLightnessOpcode.LIGHTNESS_DEFAULT_GET: LightLightnessGet,
-    LightLightnessOpcode.LIGHTNESS_DEFAULT_STATUS: LightLightnessDefault,
-    LightLightnessOpcode.LIGHTNESS_RANGE_GET: LightLightnessGet,
-    LightLightnessOpcode.LIGHTNESS_RANGE_STATUS: LightLightnessRangeStatus,
-})
+LightLightnessMessage = SwitchStruct(
+    "opcode" / Opcode(LightLightnessOpcode),
+    "params" / Switch(
+        this.opcode,
+        {
+            LightLightnessOpcode.LIGHTNESS_GET: LightLightnessGet,
+            LightLightnessOpcode.LIGHTNESS_SET: LightLightnessSet,
+            LightLightnessOpcode.LIGHTNESS_SET_UNACKNOWLEDGED: LightLightnessSet,
+            LightLightnessOpcode.LIGHTNESS_STATUS: LightLightnessStatus,
+            LightLightnessOpcode.LIGHTNESS_LINEAR_GET: LightLightnessGet,
+            LightLightnessOpcode.LIGHTNESS_LINEAR_SET: LightLightnessSet,
+            LightLightnessOpcode.LIGHTNESS_LINEAR_SET_UNACKNOWLEDGED: LightLightnessSet,
+            LightLightnessOpcode.LIGHTNESS_LINEAR_STATUS: LightLightnessStatus,
+            LightLightnessOpcode.LIGHTNESS_LAST_GET: LightLightnessGet,
+            LightLightnessOpcode.LIGHTNESS_LAST_STATUS: LightLightnessDefault,
+            LightLightnessOpcode.LIGHTNESS_DEFAULT_GET: LightLightnessGet,
+            LightLightnessOpcode.LIGHTNESS_DEFAULT_STATUS: LightLightnessDefault,
+            LightLightnessOpcode.LIGHTNESS_RANGE_GET: LightLightnessGet,
+            LightLightnessOpcode.LIGHTNESS_RANGE_STATUS: LightLightnessRangeStatus,
+        }
+    )
+)
 
-LightLightnessSetupMessage = OpcodeMessage({
-    LightLightnessSetupOpcode.LIGHTNESS_DEFAULT_SET: LightLightnessDefault,
-    LightLightnessSetupOpcode.LIGHTNESS_DEFAULT_SET_UNACKNOWLEDGED: LightLightnessDefault,
-    LightLightnessSetupOpcode.LIGHTNESS_RANGE_SET: LightLightnessRange,
-    LightLightnessSetupOpcode.LIGHTNESS_RANGE_SET_UNACKNOWLEDGED: LightLightnessRange,
-})
+LightLightnessSetupMessage = SwitchStruct(
+    "opcode" / Opcode(LightLightnessSetupOpcode),
+    "params" / Switch(
+        this.opcode,
+        {
+            LightLightnessSetupOpcode.LIGHTNESS_DEFAULT_SET: LightLightnessDefault,
+            LightLightnessSetupOpcode.LIGHTNESS_DEFAULT_SET_UNACKNOWLEDGED: LightLightnessDefault,
+            LightLightnessSetupOpcode.LIGHTNESS_RANGE_SET: LightLightnessRange,
+            LightLightnessSetupOpcode.LIGHTNESS_RANGE_SET_UNACKNOWLEDGED: LightLightnessRange,
+        }
+    )
+)
 # fmt: on

--- a/bluetooth_mesh/messages/generic/light/lightness.py
+++ b/bluetooth_mesh/messages/generic/light/lightness.py
@@ -80,8 +80,8 @@ LightLightnessStatusOptional = Struct(
 )
 
 LightLightnessStatus = Select(
-    LightLightnessStatusOptional,
-    LightLightnessStatusMinimal
+    optional=LightLightnessStatusOptional,
+    minimal=LightLightnessStatusMinimal
 )
 
 LightLightnessRange = Struct(
@@ -105,8 +105,8 @@ LightLightnessSetOptional = Struct(
 )
 
 LightLightnessSet = Select(
-    LightLightnessSetOptional,
-    LightLightnessSetMinimal
+    optional=LightLightnessSetOptional,
+    minimal=LightLightnessSetMinimal
 )
 
 LightLightnessMessage = OpcodeMessage({

--- a/bluetooth_mesh/messages/generic/light/lightness.py
+++ b/bluetooth_mesh/messages/generic/light/lightness.py
@@ -21,7 +21,7 @@
 #
 from enum import IntEnum
 
-from construct import Embedded, Int8ul, Int16ul, Select, Struct, Switch, this
+from construct import Embedded, Int8ul, Int16ul, Struct, Switch, this
 
 from bluetooth_mesh.messages.config import StatusCodeAdapter
 from bluetooth_mesh.messages.generics import (
@@ -29,7 +29,7 @@ from bluetooth_mesh.messages.generics import (
     TransitionTime,
     TransitionTimeAdapter,
 )
-from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct
+from bluetooth_mesh.messages.util import EnumAdapter, NamedSelect, Opcode, SwitchStruct
 
 
 class LightLightnessOpcode(IntEnum):
@@ -79,7 +79,7 @@ LightLightnessStatusOptional = Struct(
     "remaining_time" / TransitionTimeAdapter(TransitionTime, allow_unknown=True)
 )
 
-LightLightnessStatus = Select(
+LightLightnessStatus = NamedSelect(
     optional=LightLightnessStatusOptional,
     minimal=LightLightnessStatusMinimal
 )
@@ -104,7 +104,7 @@ LightLightnessSetOptional = Struct(
     Embedded(OptionalSetParameters)
 )
 
-LightLightnessSet = Select(
+LightLightnessSet = NamedSelect(
     optional=LightLightnessSetOptional,
     minimal=LightLightnessSetMinimal
 )

--- a/bluetooth_mesh/messages/generic/onoff.py
+++ b/bluetooth_mesh/messages/generic/onoff.py
@@ -21,14 +21,16 @@
 #
 from enum import IntEnum
 
-from construct import Int8ul, Struct, Switch, this
+from construct import Int8ul, Struct, this
 
 from bluetooth_mesh.messages.generics import (
     Delay,
     TransitionTime,
     TransitionTimeAdapter,
 )
-from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct, NamedSelect
+from bluetooth_mesh.messages.util import EnumAdapter
+from bluetooth_mesh.messages.util import EnumSwitch as Switch
+from bluetooth_mesh.messages.util import NamedSelect, Opcode, SwitchStruct
 
 
 class GenericOnOffOpcode(IntEnum):

--- a/bluetooth_mesh/messages/generic/onoff.py
+++ b/bluetooth_mesh/messages/generic/onoff.py
@@ -50,7 +50,10 @@ GenericOnOffSetOptional = Struct(
     "delay" / Delay(Int8ul),
 )
 
-GenericOnOffSet = Select(GenericOnOffSetOptional, GenericOnOffSetMinimal)
+GenericOnOffSet = Select(
+    optional=GenericOnOffSetOptional,
+    minimal=GenericOnOffSetMinimal
+)
 
 GenericOnOffStatusMinimal = Struct("present_onoff" / Int8ul)
 
@@ -60,7 +63,10 @@ GenericOnOffStatusOptional = Struct(
     "remaining_time" / TransitionTimeAdapter(TransitionTime, allow_unknown=True),
 )
 
-GenericOnOffStatus = Select(GenericOnOffStatusOptional, GenericOnOffStatusMinimal)
+GenericOnOffStatus = Select(
+    optional=GenericOnOffStatusOptional,
+    minimal=GenericOnOffStatusMinimal
+)
 
 
 GenericOnOffMessage = Struct(

--- a/bluetooth_mesh/messages/generic/onoff.py
+++ b/bluetooth_mesh/messages/generic/onoff.py
@@ -38,10 +38,13 @@ class GenericOnOffOpcode(IntEnum):
     ONOFF_STATUS = 0x8204
 
 
-# fmt: on
+# fmt: off
 GenericOnOffGet = Struct()
 
-GenericOnOffSetMinimal = Struct("onoff" / Int8ul, "tid" / Int8ul)
+GenericOnOffSetMinimal = Struct(
+    "onoff" / Int8ul,
+    "tid" / Int8ul
+)
 
 GenericOnOffSetOptional = Struct(
     "onoff" / Int8ul,
@@ -55,7 +58,9 @@ GenericOnOffSet = Select(
     minimal=GenericOnOffSetMinimal
 )
 
-GenericOnOffStatusMinimal = Struct("present_onoff" / Int8ul)
+GenericOnOffStatusMinimal = Struct(
+    "present_onoff" / Int8ul
+)
 
 GenericOnOffStatusOptional = Struct(
     "present_onoff" / Int8ul,
@@ -71,8 +76,7 @@ GenericOnOffStatus = Select(
 
 GenericOnOffMessage = Struct(
     "opcode" / Opcode(GenericOnOffOpcode),
-    "params"
-    / Switch(
+    "params" / Switch(
         this.opcode,
         {
             GenericOnOffOpcode.ONOFF_GET: GenericOnOffGet,
@@ -82,4 +86,4 @@ GenericOnOffMessage = Struct(
         },
     ),
 )
-# fmt: off
+# fmt: on

--- a/bluetooth_mesh/messages/generic/onoff.py
+++ b/bluetooth_mesh/messages/generic/onoff.py
@@ -28,7 +28,7 @@ from bluetooth_mesh.messages.generics import (
     TransitionTime,
     TransitionTimeAdapter,
 )
-from bluetooth_mesh.messages.util import EnumAdapter, Opcode
+from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct
 
 
 class GenericOnOffOpcode(IntEnum):
@@ -74,7 +74,7 @@ GenericOnOffStatus = Select(
 )
 
 
-GenericOnOffMessage = Struct(
+GenericOnOffMessage = SwitchStruct(
     "opcode" / Opcode(GenericOnOffOpcode),
     "params" / Switch(
         this.opcode,

--- a/bluetooth_mesh/messages/generic/onoff.py
+++ b/bluetooth_mesh/messages/generic/onoff.py
@@ -21,14 +21,14 @@
 #
 from enum import IntEnum
 
-from construct import Int8ul, Select, Struct, Switch, this
+from construct import Int8ul, Struct, Switch, this
 
 from bluetooth_mesh.messages.generics import (
     Delay,
     TransitionTime,
     TransitionTimeAdapter,
 )
-from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct
+from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct, NamedSelect
 
 
 class GenericOnOffOpcode(IntEnum):
@@ -53,7 +53,7 @@ GenericOnOffSetOptional = Struct(
     "delay" / Delay(Int8ul),
 )
 
-GenericOnOffSet = Select(
+GenericOnOffSet = NamedSelect(
     optional=GenericOnOffSetOptional,
     minimal=GenericOnOffSetMinimal
 )
@@ -68,7 +68,7 @@ GenericOnOffStatusOptional = Struct(
     "remaining_time" / TransitionTimeAdapter(TransitionTime, allow_unknown=True),
 )
 
-GenericOnOffStatus = Select(
+GenericOnOffStatus = NamedSelect(
     optional=GenericOnOffStatusOptional,
     minimal=GenericOnOffStatusMinimal
 )

--- a/bluetooth_mesh/messages/generics.py
+++ b/bluetooth_mesh/messages/generics.py
@@ -21,10 +21,11 @@
 #
 # pylint: disable=W0223
 
-from construct import Adapter, BitsInteger, BitStruct, Int8ul, Struct
+from construct import Adapter, BitsInteger, BitStruct, Float32b, Int8ul, Int16ul, Struct
 
 
 class TransitionTimeAdapter(Adapter):
+    _subcon = Float32b
     RESOLUTION = {0b00: 0.1, 0b01: 1, 0b10: 10, 0b11: 10 * 60}
 
     def __init__(self, subcon, allow_unknown=False):
@@ -50,6 +51,8 @@ class TransitionTimeAdapter(Adapter):
 
 
 class Delay(Adapter):
+    _subcon = Float32b
+
     def _decode(self, obj, context, path):
         return obj / 200
 

--- a/bluetooth_mesh/messages/health.py
+++ b/bluetooth_mesh/messages/health.py
@@ -33,7 +33,7 @@ from construct import (
     this,
 )
 
-from bluetooth_mesh.messages.util import EnumAdapter, Opcode
+from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct
 
 # fmt: off
 FaultTest = Struct(
@@ -101,7 +101,7 @@ class HealthOpcode(enum.IntEnum):
 
 
 # fmt: off
-HealthMessage = Struct(
+HealthMessage = SwitchStruct(
     "opcode" / Opcode(HealthOpcode),
     "params" / Switch(
         this.opcode,

--- a/bluetooth_mesh/messages/health.py
+++ b/bluetooth_mesh/messages/health.py
@@ -33,7 +33,7 @@ from construct import (
     this,
 )
 
-from .util import EnumAdapter, Opcode
+from bluetooth_mesh.messages.util import EnumAdapter, Opcode
 
 # fmt: off
 FaultTest = Struct(

--- a/bluetooth_mesh/messages/health.py
+++ b/bluetooth_mesh/messages/health.py
@@ -28,12 +28,13 @@ from construct import (
     Int8ul,
     Int16ul,
     Struct,
-    Switch,
     obj_,
     this,
 )
 
-from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct
+from bluetooth_mesh.messages.util import EnumAdapter
+from bluetooth_mesh.messages.util import EnumSwitch as Switch
+from bluetooth_mesh.messages.util import Opcode, SwitchStruct
 
 # fmt: off
 FaultTest = Struct(

--- a/bluetooth_mesh/messages/properties.py
+++ b/bluetooth_mesh/messages/properties.py
@@ -32,17 +32,19 @@ from construct import (
     Byte,
     BytesInteger,
     Embedded,
+    ExprAdapter,
     Flag,
+    Float32b,
     Int8sl,
     Int8ul,
     Int16sl,
     Int16ul,
     Int24ul,
     Int32ul,
-    Float32b,
     PaddedString,
     Struct,
     Switch,
+    obj_,
     this,
 )
 
@@ -201,7 +203,12 @@ class DateValidator(Adapter):
 
 
 def FixedString(size):
-    return PaddedString(size, "utf8")
+    def decode_bytes(obj, context):
+        return obj.decode() if isinstance(obj, bytes) else obj
+
+    return ExprAdapter(
+        PaddedString(size, "utf8"), obj_, decode_bytes,
+    )
 
 
 # fmt: off

--- a/bluetooth_mesh/messages/properties.py
+++ b/bluetooth_mesh/messages/properties.py
@@ -40,7 +40,6 @@ from construct import (
     Int24ul,
     Int32ul,
     PaddedString,
-    Probe,
     Struct,
     Switch,
     this,
@@ -263,7 +262,6 @@ Voltage = Struct(
 AverageVoltage = Struct(
     "voltage_value" / DefaultCountValidator(Int16ul, resolution=1/64),
     "sensing_duration" / TimeExponential8,
-    Probe(this)
 )
 
 VoltageRange = Struct(

--- a/bluetooth_mesh/messages/properties.py
+++ b/bluetooth_mesh/messages/properties.py
@@ -39,6 +39,7 @@ from construct import (
     Int16ul,
     Int24ul,
     Int32ul,
+    Float32b,
     PaddedString,
     Struct,
     Switch,
@@ -78,7 +79,7 @@ class PropertyID(IntEnum):
     DEVICE_SOFTWARE_REVISION = 0x001A
     DEVICE_UNDER_TEMPERATURE_EVENT_STATISTICS = 0x001B
     INDOOR_AMBIENT_TEMPERATURE_STATISTICAL_VALUES = 0x001C
-    INITIAL_CIE_1931_CHROMATICITY_COORDINATES = 0x001D
+    INITIAL_CIE1931_CHROMATICITY_COORDINATES = 0x001D
     INITIAL_CORRELATED_COLOR_TEMPERATURE = 0x001E
     INITIAL_LUMINOUS_FLUX = 0x001F
     INITIAL_PLANCKIAN_DISTANCE = 0x0020
@@ -129,7 +130,7 @@ class PropertyID(IntEnum):
     PRESENCE_DETECTED = 0x004D
     PRESENT_AMBIENT_LIGHT_LEVEL = 0x004E
     PRESENT_AMBIENT_TEMPERATURE = 0x004F
-    PRESENT_CIE_1931_CHROMATICITY_COORDINATES = 0x0050
+    PRESENT_CIE1931_CHROMATICITY_COORDINATES = 0x0050
     PRESENT_CORRELATED_COLOR_TEMPERATURE = 0x0051
     PRESENT_DEVICE_INPUT_POWER = 0x0052
     PRESENT_DEVICE_OPERATING_EFFICIENCY = 0x0053
@@ -169,6 +170,8 @@ class PropertyID(IntEnum):
 
 
 class TimeExponential8Validator(Adapter):
+    _subcon = Float32b
+
     def _decode(self, obj, content, path):
         return round(pow(1.1, obj - 64), 4) if obj else 0
 
@@ -177,13 +180,24 @@ class TimeExponential8Validator(Adapter):
 
 
 class DateValidator(Adapter):
+    _subcon = Int32ul
     EPOCH = datetime(1970, 1, 1)
 
     def _decode(self, obj, content, path):
-        return None if obj == 0x0 else self.EPOCH + timedelta(days=obj)
+        if obj is None:
+            return 0
+
+        return self.EPOCH + timedelta(days=obj)
 
     def _encode(self, obj, content, path):
-        return 0x0 if obj is None else (obj - self.EPOCH).days
+        if obj is None:
+            return 0
+
+        if isinstance(obj, datetime):
+            return (obj - self.EPOCH).days
+
+        return obj
+
 
 
 def FixedString(size):
@@ -502,7 +516,7 @@ PropertyDict = {
     PropertyID.DEVICE_SOFTWARE_REVISION: FixedString(8),
     PropertyID.DEVICE_UNDER_TEMPERATURE_EVENT_STATISTICS: EventStatistics,
     PropertyID.INDOOR_AMBIENT_TEMPERATURE_STATISTICAL_VALUES: Temperature8Statistics,
-    PropertyID.INITIAL_CIE_1931_CHROMATICITY_COORDINATES: ChromaticityCoordinates,
+    PropertyID.INITIAL_CIE1931_CHROMATICITY_COORDINATES: ChromaticityCoordinates,
     PropertyID.INITIAL_CORRELATED_COLOR_TEMPERATURE: CorrelatedColorTemperature,
     PropertyID.INITIAL_LUMINOUS_FLUX: LuminousFlux,
     PropertyID.INITIAL_PLANCKIAN_DISTANCE: ChromaticDistanceFromPlanckian,
@@ -553,7 +567,7 @@ PropertyDict = {
     PropertyID.PRESENCE_DETECTED: Presence,
     PropertyID.PRESENT_AMBIENT_LIGHT_LEVEL: Illuminance,
     PropertyID.PRESENT_AMBIENT_TEMPERATURE: Temperature8,
-    PropertyID.PRESENT_CIE_1931_CHROMATICITY_COORDINATES: ChromaticityCoordinates,
+    PropertyID.PRESENT_CIE1931_CHROMATICITY_COORDINATES: ChromaticityCoordinates,
     PropertyID.PRESENT_CORRELATED_COLOR_TEMPERATURE: CorrelatedColorTemperature,
     PropertyID.PRESENT_DEVICE_INPUT_POWER: Power,
     PropertyID.PRESENT_DEVICE_OPERATING_EFFICIENCY: Percentage8,

--- a/bluetooth_mesh/messages/scene.py
+++ b/bluetooth_mesh/messages/scene.py
@@ -21,23 +21,16 @@
 #
 from enum import IntEnum
 
-from construct import (
-    Array,
-    ExprValidator,
-    Int8ul,
-    Int16ul,
-    Struct,
-    Switch,
-    obj_,
-    this,
-)
+from construct import Array, ExprValidator, Int8ul, Int16ul, Struct, obj_, this
 
 from bluetooth_mesh.messages.generics import (
     Delay,
     TransitionTime,
     TransitionTimeAdapter,
 )
-from bluetooth_mesh.messages.util import EnumAdapter, NamedSelect, Opcode, SwitchStruct
+from bluetooth_mesh.messages.util import EnumAdapter
+from bluetooth_mesh.messages.util import EnumSwitch as Switch
+from bluetooth_mesh.messages.util import NamedSelect, Opcode, SwitchStruct
 
 
 class SceneOpcode(IntEnum):

--- a/bluetooth_mesh/messages/scene.py
+++ b/bluetooth_mesh/messages/scene.py
@@ -26,7 +26,6 @@ from construct import (
     ExprValidator,
     Int8ul,
     Int16ul,
-    Select,
     Struct,
     Switch,
     obj_,
@@ -38,7 +37,7 @@ from bluetooth_mesh.messages.generics import (
     TransitionTime,
     TransitionTimeAdapter,
 )
-from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct
+from bluetooth_mesh.messages.util import EnumAdapter, NamedSelect, Opcode, SwitchStruct
 
 
 class SceneOpcode(IntEnum):
@@ -75,7 +74,7 @@ SceneRecallWithTransition = Struct(
     "delay" / Delay(Int8ul),
 )
 
-SceneRecall = Select(
+SceneRecall = NamedSelect(
     optional=SceneRecallWithTransition,
     minimal=SceneRecallMinimal
 )
@@ -92,7 +91,7 @@ SceneStatusWithTargetScene = Struct(
     "remaining_time" / TransitionTimeAdapter(TransitionTime, allow_unknown=False),
 )
 
-SceneStatus = Select(
+SceneStatus = NamedSelect(
     optional=SceneStatusWithTargetScene,
     minimal=SceneStatusMinimal
 )

--- a/bluetooth_mesh/messages/scene.py
+++ b/bluetooth_mesh/messages/scene.py
@@ -38,7 +38,7 @@ from bluetooth_mesh.messages.generics import (
     TransitionTime,
     TransitionTimeAdapter,
 )
-from bluetooth_mesh.messages.util import EnumAdapter, Opcode
+from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct
 
 
 class SceneOpcode(IntEnum):
@@ -113,7 +113,7 @@ SceneSetup = Struct(
     "scene_number" / Int16ul
 )
 
-SceneMessage = Struct(
+SceneMessage = SwitchStruct(
     "opcode" / Opcode(SceneOpcode),
     "params" / Switch(
         this.opcode,

--- a/bluetooth_mesh/messages/scene.py
+++ b/bluetooth_mesh/messages/scene.py
@@ -76,8 +76,8 @@ SceneRecallWithTransition = Struct(
 )
 
 SceneRecall = Select(
-    SceneRecallWithTransition,
-    SceneRecallMinimal
+    optional=SceneRecallWithTransition,
+    minimal=SceneRecallMinimal
 )
 
 SceneStatusMinimal = Struct(
@@ -93,8 +93,8 @@ SceneStatusWithTargetScene = Struct(
 )
 
 SceneStatus = Select(
-    SceneStatusWithTargetScene,
-    SceneStatusMinimal
+    optional=SceneStatusWithTargetScene,
+    minimal=SceneStatusMinimal
 )
 
 SceneRegisterGet = Struct()

--- a/bluetooth_mesh/messages/sensor.py
+++ b/bluetooth_mesh/messages/sensor.py
@@ -55,6 +55,7 @@ from bluetooth_mesh.messages.util import (
     FieldAdapter,
     Opcode,
     SwitchStruct,
+    NamedSelect,
 )
 
 
@@ -118,7 +119,7 @@ SensorGetOptional = Struct(
     "property_id" / SensorPropertyId,
 )
 
-SensorGet = Select(
+SensorGet = NamedSelect(
     optional=SensorGetOptional,
     minimal=SensorGetMinimal
 )
@@ -160,7 +161,7 @@ SensorDescriptorOptional = Struct(
     "sensor_update_interval" / Int8ul
 )
 
-SensorDescriptorStatusItem = Select(
+SensorDescriptorStatusItem = NamedSelect(
     optional=SensorDescriptorOptional,
     minimal=SensorDescriptorMinimal
 )

--- a/bluetooth_mesh/messages/sensor.py
+++ b/bluetooth_mesh/messages/sensor.py
@@ -118,8 +118,8 @@ SensorGetOptional = Struct(
 )
 
 SensorGet = Select(
-    SensorGetOptional,
-    SensorGetMinimal
+    optional=SensorGetOptional,
+    minimal=SensorGetMinimal
 )
 
 SensorSettingsGet = Struct(
@@ -159,12 +159,12 @@ SensorDescriptorOptional = Struct(
     "sensor_update_interval" / Int8ul
 )
 
-SensorDescriptorStatus = GreedyRange(
-    Select(
-        SensorDescriptorOptional,
-        SensorDescriptorMinimal,
-    ),
+SensorDescriptorStatusItem = Select(
+    optional=SensorDescriptorOptional,
+    minimal=SensorDescriptorMinimal
 )
+
+SensorDescriptorStatus = GreedyRange(SensorDescriptorStatusItem)
 
 class _SensorData(Construct):
     def _parse(self, stream, context, path):

--- a/bluetooth_mesh/messages/silvair/debug.py
+++ b/bluetooth_mesh/messages/silvair/debug.py
@@ -38,11 +38,12 @@ from construct import (
     Padding,
     Select,
     Struct,
-    Switch,
     this,
 )
 
-from bluetooth_mesh.messages.util import DictAdapter, EnumAdapter, Opcode, SwitchStruct
+from bluetooth_mesh.messages.util import DictAdapter, EnumAdapter
+from bluetooth_mesh.messages.util import EnumSwitch as Switch
+from bluetooth_mesh.messages.util import Opcode, SwitchStruct
 
 
 class DebugOpcode(IntEnum):

--- a/bluetooth_mesh/messages/silvair/debug.py
+++ b/bluetooth_mesh/messages/silvair/debug.py
@@ -42,7 +42,7 @@ from construct import (
     this,
 )
 
-from bluetooth_mesh.messages.util import DictAdapter, EnumAdapter, Opcode
+from bluetooth_mesh.messages.util import DictAdapter, EnumAdapter, Opcode, SwitchStruct
 
 
 class DebugOpcode(IntEnum):
@@ -182,39 +182,42 @@ ArapContent = Struct(
     )
 )
 
-DebugPayload = Default(Switch(
-    this.subopcode,
-    {
-        DebugSubOpcode.RSSI_THRESHOLD_SET: RssiThreshold,
-        DebugSubOpcode.RSSI_THRESHOLD_STATUS: RssiThreshold,
-        DebugSubOpcode.RADIO_TEST: RadioTest,
-        DebugSubOpcode.TIMESLOT_TX_POWER_SET: TxPower,
-        DebugSubOpcode.TIMESLOT_TX_POWER_STATUS: TxPower,
-        DebugSubOpcode.SOFTDEVICE_TX_POWER_SET: TxPower,
-        DebugSubOpcode.SOFTDEVICE_TX_POWER_STATUS: TxPower,
-        DebugSubOpcode.UPTIME_STATUS: UptimeStatus,
-        DebugSubOpcode.LAST_SW_FAULT_STATUS: LastFault,
-        DebugSubOpcode.SYSTEM_STATS_STATUS: SystemStats,
-        DebugSubOpcode.LAST_MALLOC_FAULT_STATUS: LastFault,
-        DebugSubOpcode.LAST_FDS_FAULT_STATUS: LastFault,
-        DebugSubOpcode.BYTES_BEFORE_GARBAGE_COLLECTOR_STATUS: GarbageCollector,
-        DebugSubOpcode.PROVISIONED_APP_VERSION_STATUS: AppVersion,
-        DebugSubOpcode.FULL_FIRMWARE_VERSION_STATUS: FirmwareVersion,
-        DebugSubOpcode.IV_INDEX_STATUS: IvIndex,
-        DebugSubOpcode.GARBAGE_COLLECTOR_COUNTER_STATUS: GarbageCollectorCounter,
-        DebugSubOpcode.ARAP_LIST_SIZE_STATUS: ArapSize,
-        DebugSubOpcode.ARAP_LIST_CONTENT_GET: ArapContentGet,
-        DebugSubOpcode.ARAP_LIST_CONTENT_STATUS: ArapContent,
-    }
-), None)
-
-DebugParams = Struct(
+DebugParams = SwitchStruct(
     "subopcode" / EnumAdapter(Int8ul, DebugSubOpcode),
-    "payload" / DebugPayload,
+    "payload" / Switch(
+        this.subopcode,
+        {
+            DebugSubOpcode.RSSI_THRESHOLD_SET: RssiThreshold,
+            DebugSubOpcode.RSSI_THRESHOLD_STATUS: RssiThreshold,
+            DebugSubOpcode.RADIO_TEST: RadioTest,
+            DebugSubOpcode.TIMESLOT_TX_POWER_SET: TxPower,
+            DebugSubOpcode.TIMESLOT_TX_POWER_STATUS: TxPower,
+            DebugSubOpcode.SOFTDEVICE_TX_POWER_SET: TxPower,
+            DebugSubOpcode.SOFTDEVICE_TX_POWER_STATUS: TxPower,
+            DebugSubOpcode.UPTIME_STATUS: UptimeStatus,
+            DebugSubOpcode.LAST_SW_FAULT_STATUS: LastFault,
+            DebugSubOpcode.SYSTEM_STATS_STATUS: SystemStats,
+            DebugSubOpcode.LAST_MALLOC_FAULT_STATUS: LastFault,
+            DebugSubOpcode.LAST_FDS_FAULT_STATUS: LastFault,
+            DebugSubOpcode.BYTES_BEFORE_GARBAGE_COLLECTOR_STATUS: GarbageCollector,
+            DebugSubOpcode.PROVISIONED_APP_VERSION_STATUS: AppVersion,
+            DebugSubOpcode.FULL_FIRMWARE_VERSION_STATUS: FirmwareVersion,
+            DebugSubOpcode.IV_INDEX_STATUS: IvIndex,
+            DebugSubOpcode.GARBAGE_COLLECTOR_COUNTER_STATUS: GarbageCollectorCounter,
+            DebugSubOpcode.ARAP_LIST_SIZE_STATUS: ArapSize,
+            DebugSubOpcode.ARAP_LIST_CONTENT_GET: ArapContentGet,
+            DebugSubOpcode.ARAP_LIST_CONTENT_STATUS: ArapContent,
+        }
+    )
 )
 
-DebugMessage = Struct(
-    "opcode" / Const(DebugOpcode.SILVAIR_DEBUG, Opcode(DebugOpcode)),
-    "params" / DebugParams
+DebugMessage = SwitchStruct(
+    "opcode" / Opcode(DebugOpcode),
+    "params" / Switch(
+        this.opcode,
+        {
+            DebugOpcode.SILVAIR_DEBUG: DebugParams,
+        }
+    )
 )
 # fmt: on

--- a/bluetooth_mesh/messages/silvair/debug.py
+++ b/bluetooth_mesh/messages/silvair/debug.py
@@ -156,8 +156,8 @@ ArapSize8 = Struct(
 )
 
 ArapSize = Select(
-    ArapSize16,
-    ArapSize8,
+    new=ArapSize16,
+    old=ArapSize8,
 )
 
 ArapContentGet = Struct(

--- a/bluetooth_mesh/messages/silvair/gateway_config_server.py
+++ b/bluetooth_mesh/messages/silvair/gateway_config_server.py
@@ -33,12 +33,12 @@ from construct import (
     PaddedString,
     Select,
     Struct,
-    Switch,
     this,
 )
 
+from bluetooth_mesh.messages.util import EnumAdapter
+from bluetooth_mesh.messages.util import EnumSwitch as Switch
 from bluetooth_mesh.messages.util import (
-    EnumAdapter,
     IpAddressAdapter,
     MacAddressAdapter,
     Opcode,

--- a/bluetooth_mesh/messages/silvair/gateway_config_server.py
+++ b/bluetooth_mesh/messages/silvair/gateway_config_server.py
@@ -42,6 +42,7 @@ from bluetooth_mesh.messages.util import (
     IpAddressAdapter,
     MacAddressAdapter,
     Opcode,
+    SwitchStruct,
 )
 
 
@@ -210,30 +211,33 @@ PacketsStatus = Struct(
     "connection_state" / ConnectionState,
 )
 
-GatewayConfigPayload = Default(Switch(
-    this.subopcode,
-    {
-        GatewayConfigServerSubOpcode.GATEWAY_CONFIGURATION_SET: ConfigurationSet,
-        GatewayConfigServerSubOpcode.MTU_SIZE_SET: ConfigurationSetMtu,
-        GatewayConfigServerSubOpcode.ETHERNET_MAC_ADDRESS_SET: ConfigurationSetMacAddr,
-        GatewayConfigServerSubOpcode.SERVER_ADDRESS_AND_PORT_NUMBER_SET: ConfigurationSetServerAddrAndPortNr,
-        GatewayConfigServerSubOpcode.RECONNECT_INTERVAL_SET: ConfigurationSetReconnectInterval,
-        GatewayConfigServerSubOpcode.DNS_IP_ADDRESS_SET: ConfigurationSetDnsIpAddr,
-        GatewayConfigServerSubOpcode.IP_ADDRESS_SET: ConfigurationSetIpAddr,
-        GatewayConfigServerSubOpcode.GATEWAY_IP_ADDRESS_SET: ConfigurationSetGatewayIpAddr,
-        GatewayConfigServerSubOpcode.NETMASK_SET: ConfigurationSetNetmask,
-        GatewayConfigServerSubOpcode.GATEWAY_CONFIGURATION_STATUS: ConfigurationStatus,
-        GatewayConfigServerSubOpcode.GATEWAY_PACKETS_STATUS: PacketsStatus,
-    },
-), None)
-
-GatewayConfigParams = Struct(
+GatewayConfigParams = SwitchStruct(
     "subopcode" / EnumAdapter(Int8ul, GatewayConfigServerSubOpcode),
-    "payload" / GatewayConfigPayload
+    "payload" / Switch(
+        this.subopcode,
+        {
+            GatewayConfigServerSubOpcode.GATEWAY_CONFIGURATION_SET: ConfigurationSet,
+            GatewayConfigServerSubOpcode.MTU_SIZE_SET: ConfigurationSetMtu,
+            GatewayConfigServerSubOpcode.ETHERNET_MAC_ADDRESS_SET: ConfigurationSetMacAddr,
+            GatewayConfigServerSubOpcode.SERVER_ADDRESS_AND_PORT_NUMBER_SET: ConfigurationSetServerAddrAndPortNr,
+            GatewayConfigServerSubOpcode.RECONNECT_INTERVAL_SET: ConfigurationSetReconnectInterval,
+            GatewayConfigServerSubOpcode.DNS_IP_ADDRESS_SET: ConfigurationSetDnsIpAddr,
+            GatewayConfigServerSubOpcode.IP_ADDRESS_SET: ConfigurationSetIpAddr,
+            GatewayConfigServerSubOpcode.GATEWAY_IP_ADDRESS_SET: ConfigurationSetGatewayIpAddr,
+            GatewayConfigServerSubOpcode.NETMASK_SET: ConfigurationSetNetmask,
+            GatewayConfigServerSubOpcode.GATEWAY_CONFIGURATION_STATUS: ConfigurationStatus,
+            GatewayConfigServerSubOpcode.GATEWAY_PACKETS_STATUS: PacketsStatus,
+        },
+    )
 )
 
-GatewayConfigMessage = Struct(
-    "opcode" / Const(GatewayConfigServerOpcode.SILVAIR_GATEWAY, Opcode(GatewayConfigServerOpcode)),
-    "params" / GatewayConfigParams
+GatewayConfigMessage = SwitchStruct(
+    "opcode" / Opcode(GatewayConfigServerOpcode),
+    "params" / Switch(
+        this.opcode,
+        {
+            GatewayConfigServerOpcode.SILVAIR_GATEWAY: GatewayConfigParams
+        }
+    )
 )
 # fmt: on

--- a/bluetooth_mesh/messages/silvair/gateway_config_server.py
+++ b/bluetooth_mesh/messages/silvair/gateway_config_server.py
@@ -184,9 +184,9 @@ ConfigurationSetWithOptionalDhcpDisabled = Struct(
 )
 
 ConfigurationSet = Select(
-    ConfigurationSetWithOptionalDhcpDisabled,
-    ConfigurationSetWithOptionalDhcpEnabledWithStaticDns,
-    ConfigurationSetWithoutOptionalAutoDhcpEnabled,
+    static=ConfigurationSetWithOptionalDhcpDisabled,
+    dns=ConfigurationSetWithOptionalDhcpEnabledWithStaticDns,
+    minimal=ConfigurationSetWithoutOptionalAutoDhcpEnabled,
 )
 
 ConfigurationStatus = Struct(

--- a/bluetooth_mesh/messages/silvair/light_extended_controller.py
+++ b/bluetooth_mesh/messages/silvair/light_extended_controller.py
@@ -95,22 +95,24 @@ LightExtendedControllerSyncIntegralStatus = Struct(
     "sync_integral" / Int16ul,
 )
 
-LightExtendedControllerPayload = Struct(
+LightExtendedControllerPayload = Default(Switch(
+    this.subopcode,
+    {
+        LightExtendedControllerSubOpcode.PROPERTY_GET: LightExtendedControllerPropertyGet,
+        LightExtendedControllerSubOpcode.PROPERTY_SET: LightExtendedControllerPropertySet,
+        LightExtendedControllerSubOpcode.PROPERTY_SET_UNACKNOWLEDGED: LightExtendedControllerPropertySet,
+        LightExtendedControllerSubOpcode.PROPERTY_STATUS: LightExtendedControllerPropertyStatus,
+        LightExtendedControllerSubOpcode.SYNC_INTEGRAL_STATUS: LightExtendedControllerSyncIntegralStatus,
+    },
+), None)
+
+LightExtendedControllerParams = Struct(
     "subopcode" / EnumAdapter(Int8ul, LightExtendedControllerSubOpcode),
-    "payload" / Default(Switch(
-        this.subopcode,
-        {
-            LightExtendedControllerSubOpcode.PROPERTY_GET: LightExtendedControllerPropertyGet,
-            LightExtendedControllerSubOpcode.PROPERTY_SET: LightExtendedControllerPropertySet,
-            LightExtendedControllerSubOpcode.PROPERTY_SET_UNACKNOWLEDGED: LightExtendedControllerPropertySet,
-            LightExtendedControllerSubOpcode.PROPERTY_STATUS: LightExtendedControllerPropertyStatus,
-            LightExtendedControllerSubOpcode.SYNC_INTEGRAL_STATUS: LightExtendedControllerSyncIntegralStatus,
-        },
-    ), None)
+    "payload" / LightExtendedControllerPayload
 )
 
 LightExtendedControllerMessage = Struct(
     "opcode" / Const(LightExtendedControllerOpcode.SILVAIR_LEC, Opcode(LightExtendedControllerOpcode)),
-    "params" / LightExtendedControllerPayload
+    "params" / LightExtendedControllerParams
 )
 # fmt: on

--- a/bluetooth_mesh/messages/silvair/light_extended_controller.py
+++ b/bluetooth_mesh/messages/silvair/light_extended_controller.py
@@ -35,7 +35,7 @@ from construct import (
     this,
 )
 
-from bluetooth_mesh.messages.util import EnumAdapter, Opcode
+from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct
 
 
 class LightExtendedControllerOpcode(IntEnum):
@@ -95,24 +95,27 @@ LightExtendedControllerSyncIntegralStatus = Struct(
     "sync_integral" / Int16ul,
 )
 
-LightExtendedControllerPayload = Default(Switch(
-    this.subopcode,
-    {
-        LightExtendedControllerSubOpcode.PROPERTY_GET: LightExtendedControllerPropertyGet,
-        LightExtendedControllerSubOpcode.PROPERTY_SET: LightExtendedControllerPropertySet,
-        LightExtendedControllerSubOpcode.PROPERTY_SET_UNACKNOWLEDGED: LightExtendedControllerPropertySet,
-        LightExtendedControllerSubOpcode.PROPERTY_STATUS: LightExtendedControllerPropertyStatus,
-        LightExtendedControllerSubOpcode.SYNC_INTEGRAL_STATUS: LightExtendedControllerSyncIntegralStatus,
-    },
-), None)
-
-LightExtendedControllerParams = Struct(
+LightExtendedControllerParams = SwitchStruct(
     "subopcode" / EnumAdapter(Int8ul, LightExtendedControllerSubOpcode),
-    "payload" / LightExtendedControllerPayload
+    "payload" / Switch(
+        this.subopcode,
+        {
+            LightExtendedControllerSubOpcode.PROPERTY_GET: LightExtendedControllerPropertyGet,
+            LightExtendedControllerSubOpcode.PROPERTY_SET: LightExtendedControllerPropertySet,
+            LightExtendedControllerSubOpcode.PROPERTY_SET_UNACKNOWLEDGED: LightExtendedControllerPropertySet,
+            LightExtendedControllerSubOpcode.PROPERTY_STATUS: LightExtendedControllerPropertyStatus,
+            LightExtendedControllerSubOpcode.SYNC_INTEGRAL_STATUS: LightExtendedControllerSyncIntegralStatus,
+        }
+    )
 )
 
-LightExtendedControllerMessage = Struct(
-    "opcode" / Const(LightExtendedControllerOpcode.SILVAIR_LEC, Opcode(LightExtendedControllerOpcode)),
-    "params" / LightExtendedControllerParams
+LightExtendedControllerMessage = SwitchStruct(
+    "opcode" / Opcode(LightExtendedControllerOpcode),
+    "params" / Switch(
+        this.opcode,
+        {
+            LightExtendedControllerOpcode.SILVAIR_LEC: LightExtendedControllerParams,
+        }
+    )
 )
 # fmt: on

--- a/bluetooth_mesh/messages/silvair/light_extended_controller.py
+++ b/bluetooth_mesh/messages/silvair/light_extended_controller.py
@@ -31,11 +31,12 @@ from construct import (
     Int16ul,
     Int24ul,
     Struct,
-    Switch,
     this,
 )
 
-from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct
+from bluetooth_mesh.messages.util import EnumAdapter
+from bluetooth_mesh.messages.util import EnumSwitch as Switch
+from bluetooth_mesh.messages.util import Opcode, SwitchStruct
 
 
 class LightExtendedControllerOpcode(IntEnum):

--- a/bluetooth_mesh/messages/silvair/network_diagnostic_server.py
+++ b/bluetooth_mesh/messages/silvair/network_diagnostic_server.py
@@ -29,7 +29,6 @@ from construct import (
     Int8ul,
     Int16ul,
     Struct,
-    Switch,
     this,
 )
 
@@ -42,7 +41,9 @@ from bluetooth_mesh.messages.config import (
     UnicastUnassignedGroupAddress,
 )
 from bluetooth_mesh.messages.generic.onoff import TransitionTime
-from bluetooth_mesh.messages.util import EnumAdapter, NamedSelect, Opcode, SwitchStruct
+from bluetooth_mesh.messages.util import EnumAdapter
+from bluetooth_mesh.messages.util import EnumSwitch as Switch
+from bluetooth_mesh.messages.util import NamedSelect, Opcode, SwitchStruct
 
 MAX_RECORD_COUNT = 32
 
@@ -111,18 +112,16 @@ NetworkDiagnosticServerSubscriptionStatus = Struct(
     "record" / GreedyRange(RegistryRecord)
 )
 
-NetworkDiagnosticServerPayload = Default(Switch(
-    this.subopcode,
-    {
-        NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_SET: NetworkDiagnosticServerSubscriptionSet,
-        NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_SET_UNACK: NetworkDiagnosticServerSubscriptionSet,
-        NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_STATUS: NetworkDiagnosticServerSubscriptionStatus
-    }
-), None)
-
 NetworkDiagnosticServerParams = Struct(
     "subopcode" / EnumAdapter(Int8ul, NetworkDiagnosticServerSubOpcode),
-    "payload" / NetworkDiagnosticServerPayload
+    "payload" / Switch(
+        this.subopcode,
+        {
+            NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_SET: NetworkDiagnosticServerSubscriptionSet,
+            NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_SET_UNACK: NetworkDiagnosticServerSubscriptionSet,
+            NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_STATUS: NetworkDiagnosticServerSubscriptionStatus
+        }
+    )
 )
 
 NetworkDiagnosticSetupServerParams = SwitchStruct(

--- a/bluetooth_mesh/messages/silvair/network_diagnostic_server.py
+++ b/bluetooth_mesh/messages/silvair/network_diagnostic_server.py
@@ -28,7 +28,6 @@ from construct import (
     GreedyRange,
     Int8ul,
     Int16ul,
-    Select,
     Struct,
     Switch,
     this,
@@ -43,7 +42,7 @@ from bluetooth_mesh.messages.config import (
     UnicastUnassignedGroupAddress,
 )
 from bluetooth_mesh.messages.generic.onoff import TransitionTime
-from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct
+from bluetooth_mesh.messages.util import EnumAdapter, NamedSelect, Opcode, SwitchStruct
 
 MAX_RECORD_COUNT = 32
 
@@ -93,7 +92,7 @@ NetworkDiagnosticSetupServerPublicationSetOptional = Struct(
     "features" / ConfigHeartbeatPublicationFeatures
 )
 
-NetworkDiagnosticSetupServerPublicationSet = Select(
+NetworkDiagnosticSetupServerPublicationSet = NamedSelect(
     optional=NetworkDiagnosticSetupServerPublicationSetOptional,
     minimal=NetworkDiagnosticSetupServerPublicationSetMinimal,
 )

--- a/bluetooth_mesh/messages/silvair/network_diagnostic_server.py
+++ b/bluetooth_mesh/messages/silvair/network_diagnostic_server.py
@@ -112,36 +112,40 @@ NetworkDiagnosticServerSubscriptionStatus = Struct(
     "record" / GreedyRange(RegistryRecord)
 )
 
-NetworkDiagnosticServerPayload = Struct(
+NetworkDiagnosticServerPayload = Default(Switch(
+    this.subopcode,
+    {
+        NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_SET: NetworkDiagnosticServerSubscriptionSet,
+        NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_SET_UNACK: NetworkDiagnosticServerSubscriptionSet,
+        NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_STATUS: NetworkDiagnosticServerSubscriptionStatus
+    }
+), None)
+
+NetworkDiagnosticServerParams = Struct(
     "subopcode" / EnumAdapter(Int8ul, NetworkDiagnosticServerSubOpcode),
-    "payload" / Default(Switch(
-        this.subopcode,
-        {
-            NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_SET: NetworkDiagnosticServerSubscriptionSet,
-            NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_SET_UNACK: NetworkDiagnosticServerSubscriptionSet,
-            NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_STATUS: NetworkDiagnosticServerSubscriptionStatus
-        }
-    ), None)
+    "payload" / NetworkDiagnosticServerPayload
 )
 
-NetworkDiagnosticSetupServerPayload = Struct(
+NetworkDiagnosticSetupServerPayload = Default(Switch(
+    this.subopcode,
+    {
+        NetworkDiagnosticSetupServerSubOpcode.PUBLICATION_SET: NetworkDiagnosticSetupServerPublicationSet,
+        NetworkDiagnosticSetupServerSubOpcode.PUBLICATION_STATUS: NetworkDiagnosticSetupServerPublicationStatus,
+    }
+), None)
+
+NetworkDiagnosticSetupServerParams = Struct(
     "subopcode" / EnumAdapter(Int8ul, NetworkDiagnosticSetupServerSubOpcode),
-    "payload" / Default(Switch(
-        this.subopcode,
-        {
-            NetworkDiagnosticSetupServerSubOpcode.PUBLICATION_SET: NetworkDiagnosticSetupServerPublicationSet,
-            NetworkDiagnosticSetupServerSubOpcode.PUBLICATION_STATUS: NetworkDiagnosticSetupServerPublicationStatus,
-        }
-    ), None)
+    "payload" / NetworkDiagnosticSetupServerPayload
 )
 
 NetworkDiagnosticServerMessage = Struct(
     "opcode" / Const(NetworkDiagnosticServerOpcode.SILVAIR_NDS, Opcode(NetworkDiagnosticServerOpcode)),
-    "params" / NetworkDiagnosticServerPayload
+    "params" / NetworkDiagnosticServerParams
 )
 
 NetworkDiagnosticSetupServerMessage = Struct(
     "opcode" / Const(NetworkDiagnosticSetupServerOpcode.SILVAIR_NDS_SETUP, Opcode(NetworkDiagnosticSetupServerOpcode)),
-    "params" / NetworkDiagnosticSetupServerPayload
+    "params" / NetworkDiagnosticSetupServerParams
 )
 # fmt: on

--- a/bluetooth_mesh/messages/silvair/network_diagnostic_server.py
+++ b/bluetooth_mesh/messages/silvair/network_diagnostic_server.py
@@ -94,8 +94,8 @@ NetworkDiagnosticSetupServerPublicationSetOptional = Struct(
 )
 
 NetworkDiagnosticSetupServerPublicationSet = Select(
-    NetworkDiagnosticSetupServerPublicationSetOptional,
-    NetworkDiagnosticSetupServerPublicationSetMinimal,
+    optional=NetworkDiagnosticSetupServerPublicationSetOptional,
+    minimal=NetworkDiagnosticSetupServerPublicationSetMinimal,
 )
 
 NetworkDiagnosticSetupServerPublicationStatus = NetworkDiagnosticSetupServerPublicationSet

--- a/bluetooth_mesh/messages/silvair/network_diagnostic_server.py
+++ b/bluetooth_mesh/messages/silvair/network_diagnostic_server.py
@@ -24,10 +24,11 @@ from enum import IntEnum
 from construct import (
     Const,
     Default,
+    Embedded,
     GreedyRange,
     Int8ul,
     Int16ul,
-    Optional,
+    Select,
     Struct,
     Switch,
     this,
@@ -79,13 +80,22 @@ RegistryRecord = Struct(
     "max_hops" / ConfigHeartbeatHops
 )
 
-NetworkDiagnosticSetupServerPublicationSet = Struct(
+NetworkDiagnosticSetupServerPublicationSetMinimal = Struct(
     "destination" / UnicastUnassignedGroupAddress,
     "count" / Int16ul,
     "period" / TransitionTime,
     "ttl" / TTL,
     "net_key_index" / Int12ul,
-    "features" / Optional(ConfigHeartbeatPublicationFeatures)
+)
+
+NetworkDiagnosticSetupServerPublicationSetOptional = Struct(
+    Embedded(NetworkDiagnosticSetupServerPublicationSetMinimal),
+    "features" / ConfigHeartbeatPublicationFeatures
+)
+
+NetworkDiagnosticSetupServerPublicationSet = Select(
+    NetworkDiagnosticSetupServerPublicationSetOptional,
+    NetworkDiagnosticSetupServerPublicationSetMinimal,
 )
 
 NetworkDiagnosticSetupServerPublicationStatus = NetworkDiagnosticSetupServerPublicationSet

--- a/bluetooth_mesh/messages/silvair/network_diagnostic_server.py
+++ b/bluetooth_mesh/messages/silvair/network_diagnostic_server.py
@@ -43,7 +43,7 @@ from bluetooth_mesh.messages.config import (
     UnicastUnassignedGroupAddress,
 )
 from bluetooth_mesh.messages.generic.onoff import TransitionTime
-from bluetooth_mesh.messages.util import EnumAdapter, Opcode
+from bluetooth_mesh.messages.util import EnumAdapter, Opcode, SwitchStruct
 
 MAX_RECORD_COUNT = 32
 
@@ -126,26 +126,34 @@ NetworkDiagnosticServerParams = Struct(
     "payload" / NetworkDiagnosticServerPayload
 )
 
-NetworkDiagnosticSetupServerPayload = Default(Switch(
-    this.subopcode,
-    {
-        NetworkDiagnosticSetupServerSubOpcode.PUBLICATION_SET: NetworkDiagnosticSetupServerPublicationSet,
-        NetworkDiagnosticSetupServerSubOpcode.PUBLICATION_STATUS: NetworkDiagnosticSetupServerPublicationStatus,
-    }
-), None)
-
-NetworkDiagnosticSetupServerParams = Struct(
+NetworkDiagnosticSetupServerParams = SwitchStruct(
     "subopcode" / EnumAdapter(Int8ul, NetworkDiagnosticSetupServerSubOpcode),
-    "payload" / NetworkDiagnosticSetupServerPayload
+    "payload" / Switch(
+        this.subopcode,
+        {
+            NetworkDiagnosticSetupServerSubOpcode.PUBLICATION_SET: NetworkDiagnosticSetupServerPublicationSet,
+            NetworkDiagnosticSetupServerSubOpcode.PUBLICATION_STATUS: NetworkDiagnosticSetupServerPublicationStatus,
+        }
+    )
 )
 
-NetworkDiagnosticServerMessage = Struct(
-    "opcode" / Const(NetworkDiagnosticServerOpcode.SILVAIR_NDS, Opcode(NetworkDiagnosticServerOpcode)),
-    "params" / NetworkDiagnosticServerParams
+NetworkDiagnosticServerMessage = SwitchStruct(
+    "opcode" / Opcode(NetworkDiagnosticServerOpcode),
+    "params" / Switch(
+        this.opcode,
+        {
+            NetworkDiagnosticServerOpcode.SILVAIR_NDS: NetworkDiagnosticServerParams
+        }
+    )
 )
 
-NetworkDiagnosticSetupServerMessage = Struct(
-    "opcode" / Const(NetworkDiagnosticSetupServerOpcode.SILVAIR_NDS_SETUP, Opcode(NetworkDiagnosticSetupServerOpcode)),
-    "params" / NetworkDiagnosticSetupServerParams
+NetworkDiagnosticSetupServerMessage = SwitchStruct(
+    "opcode" / Opcode(NetworkDiagnosticSetupServerOpcode),
+    "params" / Switch(
+        this.opcode,
+        {
+            NetworkDiagnosticSetupServerOpcode.SILVAIR_NDS_SETUP: NetworkDiagnosticSetupServerParams
+        }
+    )
 )
 # fmt: on

--- a/bluetooth_mesh/messages/silvair/test/test_debug.py
+++ b/bluetooth_mesh/messages/silvair/test/test_debug.py
@@ -238,7 +238,10 @@ invalid_build = [
 
 @pytest.mark.parametrize("encoded,subopcode,payload", valid + valid_parse)
 def test_parse_valid(encoded, subopcode, payload):
-    assert DebugParams.parse(encoded) == dict(subopcode=subopcode, payload=payload)
+    decoded = DebugParams.parse(encoded)
+    assert decoded.subopcode == subopcode
+    assert decoded.payload == payload
+    assert decoded[subopcode.name.lower()] == payload
 
 
 @pytest.mark.parametrize("encoded,subopcode,payload", valid + invalid_build)

--- a/bluetooth_mesh/messages/silvair/test/test_debug.py
+++ b/bluetooth_mesh/messages/silvair/test/test_debug.py
@@ -21,7 +21,7 @@
 #
 import pytest
 
-from bluetooth_mesh.messages.silvair.debug import DebugPayload, DebugSubOpcode
+from bluetooth_mesh.messages.silvair.debug import DebugParams, DebugSubOpcode
 
 # fmt: off
 valid = [
@@ -236,11 +236,11 @@ invalid_build = [
 # fmt: on
 
 
-@pytest.mark.parametrize("encoded,subopcode,data", valid + valid_parse)
-def test_parse_valid(encoded, subopcode, data):
-    assert DebugPayload.parse(encoded) == dict(subopcode=subopcode, data=data)
+@pytest.mark.parametrize("encoded,subopcode,payload", valid + valid_parse)
+def test_parse_valid(encoded, subopcode, payload):
+    assert DebugParams.parse(encoded) == dict(subopcode=subopcode, payload=payload)
 
 
-@pytest.mark.parametrize("encoded,subopcode,data", valid + invalid_build)
-def test_build_valid(encoded, subopcode, data):
-    assert DebugPayload.build(dict(subopcode=subopcode, data=data)) == encoded
+@pytest.mark.parametrize("encoded,subopcode,payload", valid + invalid_build)
+def test_build_valid(encoded, subopcode, payload):
+    assert DebugParams.build(dict(subopcode=subopcode, payload=payload)) == encoded

--- a/bluetooth_mesh/messages/silvair/test/test_gateway_config_server.py
+++ b/bluetooth_mesh/messages/silvair/test/test_gateway_config_server.py
@@ -298,6 +298,4 @@ valid = [
 
 @pytest.mark.parametrize("test, encoded, subopcode, payload", valid)
 def test_parse_valid(test, encoded, subopcode, payload):
-    print(test.parse(encoded))
-    print(dict(subopcode=subopcode, payload=payload))
     assert test.parse(encoded) == dict(subopcode=subopcode, payload=payload)

--- a/bluetooth_mesh/messages/silvair/test/test_gateway_config_server.py
+++ b/bluetooth_mesh/messages/silvair/test/test_gateway_config_server.py
@@ -24,7 +24,7 @@ import pytest
 from bluetooth_mesh.messages.silvair.gateway_config_server import (
     ConnState,
     DhcpFlag,
-    GatewayConfigPayload,
+    GatewayConfigParams,
     GatewayConfigServerSubOpcode,
     LastError,
     LinkStatus,
@@ -34,14 +34,14 @@ from bluetooth_mesh.messages.util import IPv4Address
 
 valid = [
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex("00"),
         GatewayConfigServerSubOpcode.GATEWAY_CONFIGURATION_GET,
         None,
         id="ConfigurationGet",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex("01 B004 ABCDEFABCDEF D204 D007 0B 3139322E3136382E302E31"),
         GatewayConfigServerSubOpcode.GATEWAY_CONFIGURATION_SET,
         dict(
@@ -55,7 +55,7 @@ valid = [
         id="ConfigurationSetWithoutOptionalAutoDhcpEnabled",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex(
             "01 B004 ABCDEFABCDEF D204 D007 19 7777772E72616E646F6D686F73746E616D652E636F6D2E706C"
         ),
@@ -71,7 +71,7 @@ valid = [
         id="ConfigurationSetWithoutOptionalAutoDhcpEnabledHostname",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex(
             "01 B004 ABCDEFABCDEF D204 D007 0B 3139322E3136382E302E31 0A2A0002"
         ),
@@ -88,7 +88,7 @@ valid = [
         id="ConfigurationSetWithOptionalDhcpEnabledWithStaticDns",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex(
             "01 DE03 ABCDEFABCDEF ABCD 04D2"
             "19 7777772E72616E646F6D686F73746E616D652E636F6D2E706C 0A2A0002"
@@ -106,7 +106,7 @@ valid = [
         id="ConfigurationSetWithOptionalDhcpEnabledWithStaticDnsHostname",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex(
             "01 B004 ABCDEFABCDEF D204 D007 0B 3139322E3136382E302E31 0A2A0002 C0A80002 C0A80001 08"
         ),
@@ -126,7 +126,7 @@ valid = [
         id="ConfigurationSetWithOptionalDhcpDisabled",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex(
             "01 B004 ABCDEFABCDEF D204 D007 19 7777772E72616E646F6D686F73746E616D652E636F6D2E706C"
             "0A2A0002 C0A80002 C0A80001 08"
@@ -147,35 +147,35 @@ valid = [
         id="ConfigurationSetWithOptionalDhcpDisabledHostname",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex("02"),
         GatewayConfigServerSubOpcode.GATEWAY_PACKETS_GET,
         None,
         id="PacketsGet",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex("03"),
         GatewayConfigServerSubOpcode.GATEWAY_PACKETS_CLEAR,
         None,
         id="PacketsClear",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex("04 DC05"),
         GatewayConfigServerSubOpcode.MTU_SIZE_SET,
         dict(mtu_size=1500),
         id="mtu_size",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex("05 112233445566"),
         GatewayConfigServerSubOpcode.ETHERNET_MAC_ADDRESS_SET,
         dict(mac_address="11:22:33:44:55:66"),
         id="EthernetMacAddressSet",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex("06 4522 0B 3139322E3136382E302E31"),
         GatewayConfigServerSubOpcode.SERVER_ADDRESS_AND_PORT_NUMBER_SET,
         dict(
@@ -186,7 +186,7 @@ valid = [
         id="ServerAddressAndPortNumberSet",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex("06 4522 19 7777772E72616E646F6D686F73746E616D652E636F6D2E706C"),
         GatewayConfigServerSubOpcode.SERVER_ADDRESS_AND_PORT_NUMBER_SET,
         dict(
@@ -197,42 +197,42 @@ valid = [
         id="ServerAddressAndPortNumberSetHostname",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex("07 E803"),
         GatewayConfigServerSubOpcode.RECONNECT_INTERVAL_SET,
         dict(reconnect_interval=1000),
         id="ReconnectIntervalSet",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex("08 0A2A0002"),
         GatewayConfigServerSubOpcode.DNS_IP_ADDRESS_SET,
         dict(dns_ip_address=IPv4Address("10.42.0.2")),
         id="DnsIpAddressSet",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex("09 C0A80001"),
         GatewayConfigServerSubOpcode.IP_ADDRESS_SET,
         dict(ip_address=IPv4Address("192.168.0.1")),
         id="IpAddressSet",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex("0A C0A80C03"),
         GatewayConfigServerSubOpcode.GATEWAY_IP_ADDRESS_SET,
         dict(gateway_ip_address=IPv4Address("192.168.12.03")),
         id="GatewayIpAddressSet",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex("0B 08"),
         GatewayConfigServerSubOpcode.NETMASK_SET,
         dict(netmask=8),
         id="NetmaskSet",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex(
             "0C 0A B202 DDDDEFABCDEF 1111 2222 0F 7777772E74657374696E672E636F6D 7B2C0515 C0A80A02 C0A80A01 0A 00 00"
         ),
@@ -255,7 +255,7 @@ valid = [
         id="ConfigurationStatus",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex(
             "0C 0A B202 DDDDEFABCDEF 1111 2222 00 C0A80A02 C0A80A02 C0A80A01 0A 02 00"
         ),
@@ -278,7 +278,7 @@ valid = [
         id="ConfigurationStatusEmptyHostname",
     ),
     pytest.param(
-        GatewayConfigPayload,
+        GatewayConfigParams,
         bytes.fromhex("0D 0000 0002 03E8 92"),
         GatewayConfigServerSubOpcode.GATEWAY_PACKETS_STATUS,
         dict(

--- a/bluetooth_mesh/messages/silvair/test/test_gateway_config_server.py
+++ b/bluetooth_mesh/messages/silvair/test/test_gateway_config_server.py
@@ -298,4 +298,7 @@ valid = [
 
 @pytest.mark.parametrize("test, encoded, subopcode, payload", valid)
 def test_parse_valid(test, encoded, subopcode, payload):
-    assert test.parse(encoded) == dict(subopcode=subopcode, payload=payload)
+    decoded = test.parse(encoded)
+    assert decoded.subopcode == subopcode
+    assert decoded.payload == payload
+    assert decoded[subopcode.name.lower()] == payload

--- a/bluetooth_mesh/messages/silvair/test/test_network_diagnostic_server.py
+++ b/bluetooth_mesh/messages/silvair/test/test_network_diagnostic_server.py
@@ -23,23 +23,23 @@ import pytest
 from construct import ValidationError
 
 from bluetooth_mesh.messages.silvair.network_diagnostic_server import (
-    NetworkDiagnosticServerPayload,
+    NetworkDiagnosticServerParams,
     NetworkDiagnosticServerSubOpcode,
-    NetworkDiagnosticSetupServerPayload,
+    NetworkDiagnosticSetupServerParams,
     NetworkDiagnosticSetupServerSubOpcode,
 )
 
 # fmt: off
 valid = [
     pytest.param(
-        NetworkDiagnosticSetupServerPayload,
+        NetworkDiagnosticSetupServerParams,
         bytes.fromhex("00"),
         NetworkDiagnosticSetupServerSubOpcode.PUBLICATION_GET,
         None,
         id='PublicationGet'
     ),
     pytest.param(
-        NetworkDiagnosticSetupServerPayload,
+        NetworkDiagnosticSetupServerParams,
         bytes.fromhex("01 1234 AAAA 82 03 1000"),
         NetworkDiagnosticSetupServerSubOpcode.PUBLICATION_SET,
         dict(
@@ -53,7 +53,7 @@ valid = [
         id='PublicationSet (no features)'
     ),
     pytest.param(
-        NetworkDiagnosticSetupServerPayload,
+        NetworkDiagnosticSetupServerParams,
         bytes.fromhex("01 1234 AAAA 82 03 1000 0300"),
         NetworkDiagnosticSetupServerSubOpcode.PUBLICATION_SET,
         dict(
@@ -67,7 +67,7 @@ valid = [
         id="PublicationSet (with features)"
     ),
     pytest.param(
-        NetworkDiagnosticSetupServerPayload,
+        NetworkDiagnosticSetupServerParams,
         bytes.fromhex("02 1234 AAAA 82 03 1000"),
         NetworkDiagnosticSetupServerSubOpcode.PUBLICATION_STATUS,
         dict(
@@ -81,7 +81,7 @@ valid = [
         id="PublicationStatus (no features)"
     ),
     pytest.param(
-        NetworkDiagnosticSetupServerPayload,
+        NetworkDiagnosticSetupServerParams,
         bytes.fromhex("02 1234 AAAA 82 03 1000 0300"),
         NetworkDiagnosticSetupServerSubOpcode.PUBLICATION_STATUS,
         dict(
@@ -95,14 +95,14 @@ valid = [
         id="PublicationStatus (with features)"
     ),
     pytest.param(
-        NetworkDiagnosticServerPayload,
+        NetworkDiagnosticServerParams,
         bytes.fromhex("00"),
         NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_GET,
         None,
         id="SubscriptionGet"
     ),
     pytest.param(
-        NetworkDiagnosticServerPayload,
+        NetworkDiagnosticServerParams,
         bytes.fromhex("01 1234 AAAA"),
         NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_SET,
         dict(
@@ -112,7 +112,7 @@ valid = [
         id="SubscriptionSet"
     ),
     pytest.param(
-        NetworkDiagnosticServerPayload,
+        NetworkDiagnosticServerParams,
         bytes.fromhex("03 1234 AAAA 20 5678 BBBB 00 00"),
         NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_STATUS,
         dict(
@@ -124,7 +124,7 @@ valid = [
         id="SubscriptionStatus (one record)"
     ),
     pytest.param(
-        NetworkDiagnosticServerPayload,
+        NetworkDiagnosticServerParams,
         bytes.fromhex("03 1234 AAAA 20 5678 BBBB 00 00 9101 CCCC 01 01"),
         NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_STATUS,
         dict(
@@ -154,7 +154,7 @@ def test_build_valid(klass, encoded, subopcode, payload):
 
 def test_prohibited_destination_addr_publication_set():
     with pytest.raises(ValidationError):
-        NetworkDiagnosticServerPayload.build(
+        NetworkDiagnosticServerParams.build(
             dict(
                 subopcode=NetworkDiagnosticSetupServerSubOpcode.PUBLICATION_SET,
                 payload=dict(
@@ -171,7 +171,7 @@ def test_prohibited_destination_addr_publication_set():
 
 def test_prohibited_destination_addr_subscription_set():
     with pytest.raises(ValidationError):
-        NetworkDiagnosticServerPayload.build(
+        NetworkDiagnosticServerParams.build(
             dict(
                 subopcode=NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_SET,
                 payload=dict(destination=0xFF00, period=0xAAAA),
@@ -181,7 +181,7 @@ def test_prohibited_destination_addr_subscription_set():
 
 def test_prohibited_source_addr_subscription_stat():
     with pytest.raises(ValidationError):
-        NetworkDiagnosticServerPayload.build(
+        NetworkDiagnosticServerParams.build(
             dict(
                 subopcode=NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_STATUS,
                 payload=dict(

--- a/bluetooth_mesh/messages/silvair/test/test_network_diagnostic_server.py
+++ b/bluetooth_mesh/messages/silvair/test/test_network_diagnostic_server.py
@@ -144,7 +144,8 @@ valid = [
 
 @pytest.mark.parametrize("klass,encoded,subopcode,payload", valid)
 def test_parse_valid(klass, encoded, subopcode, payload):
-    assert klass.parse(encoded) == dict(subopcode=subopcode, payload=payload)
+    assert klass.parse(encoded).subopcode == subopcode
+    assert klass.parse(encoded).payload == payload
 
 
 @pytest.mark.parametrize("klass,encoded,subopcode,payload", valid)

--- a/bluetooth_mesh/messages/test/test_access.py
+++ b/bluetooth_mesh/messages/test/test_access.py
@@ -33,6 +33,11 @@ valid = [
                 "test_id": 0,
                 "company_id": 0x0136,
                 "fault_array": [0x03, 0x04, 0x05]
+            },
+            "current_status": {
+                "test_id": 0,
+                "company_id": 0x0136,
+                "fault_array": [0x03, 0x04, 0x05]
             }
         },
         id="1 byte opcode"
@@ -42,6 +47,10 @@ valid = [
         {
             "opcode": 0x8032,
             "params": {
+                "test_id": 1,
+                "company_id": 0x0136
+            },
+            "fault_test": {
                 "test_id": 1,
                 "company_id": 0x0136
             }

--- a/bluetooth_mesh/messages/test/test_capnproto.py
+++ b/bluetooth_mesh/messages/test/test_capnproto.py
@@ -1,0 +1,283 @@
+#
+# python-bluetooth-mesh - Bluetooth Mesh for Python
+#
+# Copyright (C) 2019  SILVAIR sp. z o.o.
+#
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+#
+import enum
+import json
+import logging
+import re
+import sys
+from datetime import datetime
+from tempfile import NamedTemporaryFile
+
+import construct
+import pytest
+
+from bluetooth_mesh.messages import AccessMessage
+from bluetooth_mesh.messages.util import Opcode
+
+if sys.version_info >= (3, 7):
+    import capnp
+    from bluetooth_mesh.messages.capnproto import generate
+
+valid = [
+    # config
+    bytes.fromhex("02003601CE00FECAEFBE0BB000000000"),
+    bytes.fromhex("8002000b00010000012100"),
+    bytes.fromhex("8039010203040506070809"),
+    # ctl
+    bytes.fromhex("826522223333ff323c"),
+    # nds
+    bytes.fromhex("FD3601011234AAAA82031000"),
+    bytes.fromhex("FD3601011234AAAA820310000300"),
+    # sensor
+    bytes.fromhex("8230"),
+    bytes.fromhex("82300400"),
+    bytes.fromhex("8231"),
+    bytes.fromhex("82310700"),
+    bytes.fromhex("510c00000000040b0c"),
+    bytes.fromhex("511900"),
+    bytes.fromhex("510c00000000020b0c1f00efcdab071b1c"),
+    bytes.fromhex("52e20ac800"),
+    bytes.fromhex("52220b2003"),
+    bytes.fromhex("52440da244ff"),
+    ##vendor sensor
+    # bytes.fromhex("52099040a244ff0000"),
+    bytes.fromhex("52440da244ff220b2003"),
+    bytes.fromhex("583000010004000900"),
+    bytes.fromhex("583000"),
+    bytes.fromhex("5957005700c800"),
+    bytes.fromhex("5b5700570001c800"),
+    bytes.fromhex("5b5700020001c80039"),
+    bytes.fromhex("5957005700c800"),
+    bytes.fromhex("5957000200c80039"),
+    bytes.fromhex("5905000500200354"),
+    bytes.fromhex("5957000200c80000"),
+    bytes.fromhex("59590059000003"),
+    bytes.fromhex("5942004d0001"),
+    bytes.fromhex("594200420050"),
+    bytes.fromhex("590a003600b80b00"),
+    bytes.fromhex("596d006d000a0000"),
+    ##no value
+    # bytes.fromhex("596d006d00ffffff"),
+    bytes.fromhex("59550055001a2700"),
+    bytes.fromhex("594c004c001b1a"),
+    bytes.fromhex("596c006c00ff1b1a"),
+    ##no value
+    # bytes.fromhex("596c006c00ffffff"),
+    bytes.fromhex("59680068000500"),
+    bytes.fromhex("5967006700050001007040"),
+    bytes.fromhex("590e000e006162636465666768"),
+    bytes.fromhex("590e000e006162636465660000"),
+    bytes.fromhex(
+        "5911001100616263646566676861626364656667686162636465666768616263646566676861626364"
+    ),
+    bytes.fromhex("596a006a00a244ff"),
+    bytes.fromhex("592e002e0044ff"),
+    bytes.fromhex("593200320044ff0000"),
+    bytes.fromhex("5952005200a08601"),
+    bytes.fromhex("5916001600e80300d007000f2700"),
+    bytes.fromhex("594f004f001f"),
+    bytes.fromhex("594f004f00e1"),
+    bytes.fromhex("5954005400e620"),
+    bytes.fromhex("59450045003102dc6e71"),
+    bytes.fromhex("591400140092096400f8f8204e71"),
+    bytes.fromhex("5913001300dc6e"),
+    bytes.fromhex("5901000100186da2"),
+    bytes.fromhex("5960006000a244ff6da2"),
+    bytes.fromhex("592a002a00690140000000f0ff54"),
+    bytes.fromhex("594900490000000006f0ff"),
+    bytes.fromhex("59470047009709640000007d1571"),
+    bytes.fromhex("594600460000007d15"),
+    bytes.fromhex("5921002100000001007d15"),
+    bytes.fromhex("5970007000020000"),
+    bytes.fromhex("59060006000020"),
+    bytes.fromhex("5940004000020000"),
+    bytes.fromhex("591f001f00d007"),
+    bytes.fromhex("5941004100e803d007"),
+    bytes.fromhex("593e003e00d407"),
+    bytes.fromhex("590f000f00ffeeddccbbaa"),
+    bytes.fromhex("590700070064"),
+    bytes.fromhex("595e005e009227"),
+    bytes.fromhex("5951005100b80b"),
+    bytes.fromhex("590a000a0004f0"),
+    bytes.fromhex("590b000b002a00"),
+    bytes.fromhex("590c000c00de4600"),
+    bytes.fromhex("5950005000ee00cdab"),
+    bytes.fromhex("590800080064"),
+    bytes.fromhex("59080008009c"),
+    bytes.fromhex("596100610088aa00bbbb"),
+    bytes.fromhex("5962006200881a27001a2700"),
+    bytes.fromhex("596400640088ffffe620"),
+    bytes.fromhex("5965006500880000cdab"),
+    bytes.fromhex("59660066008820032003"),
+    # light
+    bytes.fromhex("824b"),
+    bytes.fromhex("824cbbaa22"),
+    bytes.fromhex("824c010022"),
+    bytes.fromhex("824c000031323c"),
+    bytes.fromhex("824d000031323c"),
+    bytes.fromhex("824e4400"),
+    bytes.fromhex("824e000031c80f"),
+    bytes.fromhex("824f"),
+    bytes.fromhex("8250bbaa01"),
+    bytes.fromhex("8250010022"),
+    bytes.fromhex("8250000031321b"),
+    bytes.fromhex("8251ff0031323c"),
+    bytes.fromhex("82520000ddbb4c"),
+    bytes.fromhex("8253"),
+    bytes.fromhex("82540000"),
+    bytes.fromhex("8255"),
+    bytes.fromhex("82560000"),
+    bytes.fromhex("8257"),
+    bytes.fromhex("82580011118888"),
+    # scene
+    bytes.fromhex("8241"),
+    bytes.fromhex("824201001e"),
+    bytes.fromhex("824301001e"),
+    bytes.fromhex("824201001ef23c"),
+    bytes.fromhex("824301001ef23c"),
+    bytes.fromhex("5e000100"),
+    bytes.fromhex("5e0001000200f2"),
+    bytes.fromhex("8244"),
+    bytes.fromhex("824500010001000200") + 14 * bytes.fromhex("0000"),
+    bytes.fromhex("82460100"),
+    bytes.fromhex("82470100"),
+    bytes.fromhex("829e0100"),
+    bytes.fromhex("829f0100"),
+    # onoff
+    bytes.fromhex("8201"),
+    bytes.fromhex("82020122"),
+    bytes.fromhex("82020122"),
+    bytes.fromhex("82020031323c"),
+    bytes.fromhex("82020031f23c"),
+    bytes.fromhex("820400"),
+    bytes.fromhex("820400014a"),
+    bytes.fromhex("82040001ff"),
+    # level
+    bytes.fromhex("8205"),
+    bytes.fromhex("8206ff7f22"),
+    bytes.fromhex("8206008022"),
+    bytes.fromhex("8206010022"),
+    bytes.fromhex("8206000031323c"),
+    bytes.fromhex("8207000031323c"),
+    bytes.fromhex("8208ff7f"),
+    bytes.fromhex("82080080"),
+    bytes.fromhex("82080000ff004a"),
+    bytes.fromhex("820800000100ff"),
+    bytes.fromhex("8209ffffff7f22"),
+    bytes.fromhex("82090000008022"),
+    bytes.fromhex("82090100000022"),
+    bytes.fromhex("82090000000031323c"),
+    bytes.fromhex("820a0000000031323c"),
+    bytes.fromhex("820bff7f22"),
+    bytes.fromhex("820b008022"),
+    bytes.fromhex("820b010022"),
+    bytes.fromhex("820b000031323c"),
+    bytes.fromhex("820c000031323c"),
+]
+
+
+@pytest.fixture(scope="session")
+def capnproto():
+    with NamedTemporaryFile("w", suffix=".capnp") as f:
+        generate(0xD988DA1AAFBE9E47, f)
+        f.flush()
+        return capnp.load(f.name)
+
+
+class CaseConverter:
+    @staticmethod
+    def _camelcase(field_name):
+        head, *tail = str(field_name).lower().replace(" ", "_").split("_")
+        return "".join([head, *(i.title() for i in tail)])
+
+    @staticmethod
+    def _snakecase(field_name):
+        pattern = re.compile(r"(?<!^)(?=[A-Z])")
+        return pattern.sub("_", field_name).lower()
+
+    @classmethod
+    def to_camelcase(cls, value):
+        if isinstance(value, construct.Container):
+            name = getattr(value, "_name", None)
+            container = {
+                cls._camelcase(k): cls.to_camelcase(v)
+                for k, v in value.items()
+                if not k.startswith("_")
+            }
+
+            return {name: container} if name else container
+
+        if isinstance(value, (set, construct.ListContainer)):
+            return [cls.to_camelcase(i) for i in value]
+
+        if isinstance(value, enum.Enum):
+            return value.value
+
+        if isinstance(value, bytes):
+            return value
+
+        if isinstance(value, datetime):
+            return (value - datetime(1970, 1, 1)).days
+
+        return value
+
+    @classmethod
+    def to_snakecase(cls, value):
+        if isinstance(value, dict):
+            container = {
+                cls._snakecase(k): cls.to_snakecase(v)
+                for k, v in value.items()
+                if not k.startswith("_")
+            }
+
+            return container
+
+        if isinstance(value, list):
+            return [cls.to_snakecase(i) for i in value]
+
+        return value
+
+
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python3.7")
+@pytest.mark.parametrize("encoded", [pytest.param(i, id=i.hex()) for i in valid])
+def test_parse_capnproto(encoded, capnproto):
+    logging.info("MESH[%i] %s", len(encoded), encoded.hex())
+
+    decoded = AccessMessage.parse(encoded)
+    logging.info("CONSTRUCT %r", decoded)
+
+    params = CaseConverter.to_camelcase(decoded)
+    logging.info("CAPNP INPUT[%i] %s", len(json.dumps(params)), json.dumps(params))
+
+    message = capnproto.AccessMessage.new_message(**params)
+    logging.info("CAPNP %r", message)
+
+    packed = message.to_bytes_packed()
+    logging.info("PACKED[%i] %s", len(packed), packed.hex())
+
+    unpacked = capnproto.AccessMessage.from_bytes_packed(packed)
+    logging.info("UNPACKED %r", unpacked)
+
+    params = CaseConverter.to_snakecase(unpacked.to_dict())
+    logging.info("CONSTRUCT INPUT %s", params)
+
+    assert AccessMessage.build(params) == encoded

--- a/bluetooth_mesh/messages/test/test_config.py
+++ b/bluetooth_mesh/messages/test/test_config.py
@@ -193,9 +193,9 @@ valid = [
         bytes.fromhex('00000101ADDEEFBEADDE'),
         {
             "location": GATTNamespaceDescriptor.UNKNOWN,
-            "SIG_number": 0x01,
+            "sig_number": 0x01,
             "vendor_number": 0x01,
-            "SIG_models": [{"model_id": 0xDEAD}],
+            "sig_models": [{"model_id": 0xDEAD}],
             "vendor_models": [{"model_id": 0xDEAD, "vendor_id": 0xBEEF}]
         },
         id="CompositionDataElement",),
@@ -204,9 +204,9 @@ valid = [
         bytes.fromhex('00000001EFBEADDE'),
         {
             "location": GATTNamespaceDescriptor.UNKNOWN,
-            "SIG_number": 0x00,
+            "sig_number": 0x00,
             "vendor_number": 0x01,
-            "SIG_models": [],
+            "sig_models": [],
             "vendor_models": [{"model_id": 0xDEAD, "vendor_id": 0xBEEF}]
         },
         id="CompositionDataElement - No SIG",),
@@ -215,9 +215,9 @@ valid = [
         bytes.fromhex('00000100ADDE'),
         {
             "location": GATTNamespaceDescriptor.UNKNOWN,
-            "SIG_number": 0x01,
+            "sig_number": 0x01,
             "vendor_number": 0x00,
-            "SIG_models": [{"model_id": 0xDEAD}],
+            "sig_models": [{"model_id": 0xDEAD}],
             "vendor_models": []
         },
         id="CompositionDataElement - No vendor"
@@ -226,17 +226,17 @@ valid = [
         CompositionData,
         bytes.fromhex('3601CE00FECAEFBE0BB000000000'),
         {
-            "CID": 0x0136,
-            "PID": 0x00CE,
-            "VID": 0xCAFE,
-            "CRPL": 0xBEEF,
+            "cid": 0x0136,
+            "pid": 0x00CE,
+            "vid": 0xCAFE,
+            "crpl": 0xBEEF,
             "features": 0xB00B,
             "elements": [
                 {
                     "location": GATTNamespaceDescriptor.UNKNOWN,
-                    "SIG_number": 0x00,
+                    "sig_number": 0x00,
                     "vendor_number": 0x00,
-                    "SIG_models": [],
+                    "sig_models": [],
                     "vendor_models": []
                 }
             ]
@@ -246,24 +246,24 @@ valid = [
         CompositionData,
         bytes.fromhex('3601CE00FECAEFBE0BB00000000000000000'),
         {
-            "CID": 0x0136,
-            "PID": 0x00CE,
-            "VID": 0xCAFE,
-            "CRPL": 0xBEEF,
+            "cid": 0x0136,
+            "pid": 0x00CE,
+            "vid": 0xCAFE,
+            "crpl": 0xBEEF,
             "features": 0xB00B,
             "elements": [
                 {
                     "location": GATTNamespaceDescriptor.UNKNOWN,
-                    "SIG_number": 0x00,
+                    "sig_number": 0x00,
                     "vendor_number": 0x00,
-                    "SIG_models": [],
+                    "sig_models": [],
                     "vendor_models": []
                 },
                 {
                     "location": GATTNamespaceDescriptor.UNKNOWN,
-                    "SIG_number": 0x00,
+                    "sig_number": 0x00,
                     "vendor_number": 0x00,
-                    "SIG_models": [],
+                    "sig_models": [],
                     "vendor_models": []
                 }
             ]
@@ -440,33 +440,33 @@ valid = [
         {
             "page": 0x00,
             "data": {
-                "CID": 0x0136,
-                "PID": 0x00CE,
-                "VID": 0xCAFE,
-                "CRPL": 0xBEEF,
+                "cid": 0x0136,
+                "pid": 0x00CE,
+                "vid": 0xCAFE,
+                "crpl": 0xBEEF,
                 "features": 0xB00B,
                 "elements": [
                     {
                         "location": GATTNamespaceDescriptor.UNKNOWN,
-                        "SIG_number": 0x00,
+                        "sig_number": 0x00,
                         "vendor_number": 0x00,
-                        "SIG_models": [],
+                        "sig_models": [],
                         "vendor_models": []
                     }
                 ]
             },
             "zero": {
-                "CID": 0x0136,
-                "PID": 0x00CE,
-                "VID": 0xCAFE,
-                "CRPL": 0xBEEF,
+                "cid": 0x0136,
+                "pid": 0x00CE,
+                "vid": 0xCAFE,
+                "crpl": 0xBEEF,
                 "features": 0xB00B,
                 "elements": [
                     {
                         "location": GATTNamespaceDescriptor.UNKNOWN,
-                        "SIG_number": 0x00,
+                        "sig_number": 0x00,
                         "vendor_number": 0x00,
-                        "SIG_models": [],
+                        "sig_models": [],
                         "vendor_models": []
                     }
                 ]
@@ -493,7 +493,7 @@ valid = [
         ConfigDefaultTTLSet,
         bytes.fromhex('00'),
         {
-            "TTL": 0x00
+            "ttl": 0x00
         },
         id="ConfigDefaultTTLSet - Min"
     ),
@@ -501,7 +501,7 @@ valid = [
         ConfigDefaultTTLSet,
         bytes.fromhex('0B'),
         {
-            "TTL": 0x0B
+            "ttl": 0x0B
         },
         id="ConfigDefaultTTLSet"
     ),
@@ -509,7 +509,7 @@ valid = [
         ConfigDefaultTTLSet,
         bytes.fromhex('7F'),
         {
-            "TTL": 0x7F
+            "ttl": 0x7F
         },
         id="ConfigDefaultTTLSet - Max"
     ),
@@ -517,7 +517,7 @@ valid = [
         ConfigDefaultTTLStatus,
         bytes.fromhex('00'),
         {
-            "TTL": 0x00
+            "ttl": 0x00
         },
         id="ConfigDefaultTTLStatus - Min"
     ),
@@ -525,7 +525,7 @@ valid = [
         ConfigDefaultTTLStatus,
         bytes.fromhex('0B'),
         {
-            "TTL": 0x0B
+            "ttl": 0x0B
         },
         id="ConfigDefaultTTLStatus"
     ),
@@ -533,7 +533,7 @@ valid = [
         ConfigDefaultTTLStatus,
         bytes.fromhex('7F'),
         {
-            "TTL": 0x7F
+            "ttl": 0x7F
         },
         id="ConfigDefaultTTLStatus - Max"
     ),
@@ -618,10 +618,10 @@ valid = [
         {
             "element_address": 0x0201,
             "publish_address": 0x0001,
-            "RFU": 0,
+            "rfu": 0,
             "credential_flag": PublishFriendshipCredentialsFlag.FRIENDSHIP_SECURITY,
             "app_key_index": 0xabc,
-            "TTL": 0x7F,
+            "ttl": 0x7F,
             "publish_period": {
                 "step_resolution": PublishPeriodStepResolution.RESOLUTION_10_MIN,
                 "number_of_steps": 0x00
@@ -643,10 +643,10 @@ valid = [
         {
             "element_address": 0x0102,
             "publish_address": 0x0304,
-            "RFU": 0,
+            "rfu": 0,
             "credential_flag": PublishFriendshipCredentialsFlag.MASTER_SECURITY,
             "app_key_index": 5,
-            "TTL": 6,
+            "ttl": 6,
             "publish_period": {
                 "step_resolution": PublishPeriodStepResolution.RESOLUTION_100_MS,
                 "number_of_steps": 7
@@ -668,10 +668,10 @@ valid = [
             "status": StatusCode.INVALID_MODEL,
             "element_address": 0x0102,
             "publish_address": 0x0304,
-            "RFU": 0,
+            "rfu": 0,
             "credential_flag": PublishFriendshipCredentialsFlag.MASTER_SECURITY,
             "app_key_index": 5,
-            "TTL": 6,
+            "ttl": 6,
             "publish_period": {
                 "step_resolution": PublishPeriodStepResolution.RESOLUTION_100_MS,
                 "number_of_steps": 7
@@ -862,7 +862,7 @@ valid = [
             "destination": 0x0201,
             "count": 4,
             "period": 8,
-            "TTL": 0x05,
+            "ttl": 0x05,
             "features": {5, 6, 13, 14, 15},
             "net_key_index": 0x908,
         },
@@ -875,7 +875,7 @@ valid = [
             "destination": 0x0201,
             "count": float('inf'),
             "period": 32,
-            "TTL": 0x05,
+            "ttl": 0x05,
             "features": {5, 6, 13, 14, 15},
             "net_key_index": 0x908,
         },
@@ -888,7 +888,7 @@ valid = [
             "destination": 0x0201,
             "count": float('inf'),
             "period": 0x8000,
-            "TTL": 0x05,
+            "ttl": 0x05,
             "features": {5, 6, 13, 14, 15},
             "net_key_index": 0x908,
         },
@@ -913,7 +913,7 @@ build_valid = [
         bytes.fromhex('00000101ADDEEFBEADDE'),
         {
             "location": GATTNamespaceDescriptor.UNKNOWN,
-            "SIG_models": [{
+            "sig_models": [{
                 "model_id": 0xDEAD
             }],
             "vendor_models": [{
@@ -928,7 +928,7 @@ build_valid = [
         bytes.fromhex('00000001EFBEADDE'),
         {
             "location": GATTNamespaceDescriptor.UNKNOWN,
-            "SIG_models": [],
+            "sig_models": [],
             "vendor_models": [{
                 "model_id": 0xDEAD,
                 "vendor_id": 0xBEEF
@@ -941,7 +941,7 @@ build_valid = [
         bytes.fromhex('00000100ADDE'),
         {
             "location": GATTNamespaceDescriptor.UNKNOWN,
-            "SIG_models": [{
+            "sig_models": [{
                 "model_id": 0xDEAD
             }],
             "vendor_models": []
@@ -982,7 +982,7 @@ build_invalid = [
             "destination": 0x0201,
             "count": 1,
             "period": 0x8001,
-            "TTL": 0x05,
+            "ttl": 0x05,
             "features": {5, 6, 13, 14, 15},
             "net_key_index": 0x0908
         },
@@ -995,7 +995,7 @@ build_invalid = [
             "destination": 0x0201,
             "count": 1,
             "period": float('inf'),
-            "TTL": 0x05,
+            "ttl": 0x05,
             "features": {5, 6, 13, 14, 15},
             "net_key_index": 0x0908
         },

--- a/bluetooth_mesh/messages/test/test_config.py
+++ b/bluetooth_mesh/messages/test/test_config.py
@@ -454,6 +454,22 @@ valid = [
                         "vendor_models": []
                     }
                 ]
+            },
+            "zero": {
+                "CID": 0x0136,
+                "PID": 0x00CE,
+                "VID": 0xCAFE,
+                "CRPL": 0xBEEF,
+                "features": 0xB00B,
+                "elements": [
+                    {
+                        "location": GATTNamespaceDescriptor.UNKNOWN,
+                        "SIG_number": 0x00,
+                        "vendor_number": 0x00,
+                        "SIG_models": [],
+                        "vendor_models": []
+                    }
+                ]
             }
         },
         id="ConfigCompositionDataStatus - page 0",),
@@ -462,7 +478,8 @@ valid = [
         bytes.fromhex('01CAFE'),
         {
             "page": 0x01,
-            "data": bytes.fromhex('CAFE')
+            "data": bytes.fromhex('CAFE'),
+            "first": bytes.fromhex('CAFE')
         },
         id="ConfigCompositionDataStatus - not page 0"
     ),
@@ -1014,17 +1031,18 @@ def test_build_invalid(message, decoded, exception):
         message.build(obj=decoded)
 
 
-def test_build_config_message():
-    key = bytes.fromhex("deadbeef" * 4)
+@pytest.mark.parametrize("key", ["params", "appkey_add"])
+def test_build_config_message(key):
+    app_key = bytes.fromhex("deadbeef" * 4)
 
     data = ConfigMessage.build(
-        dict(
-            opcode=ConfigOpcode.APPKEY_ADD,
-            params=dict(app_key_index=1, net_key_index=1, app_key=key,),
-        )
+        {
+            "opcode": ConfigOpcode.APPKEY_ADD,
+            key: dict(app_key_index=1, net_key_index=1, app_key=app_key,),
+        }
     )
 
-    assert data == bytes.fromhex("00011000") + key
+    assert data == bytes.fromhex("00011000") + app_key
 
 
 def test_parse_config_message():
@@ -1035,6 +1053,7 @@ def test_parse_config_message():
     assert msg == dict(
         opcode=ConfigOpcode.APPKEY_ADD,
         params=dict(app_key_index=1, net_key_index=1, app_key=key,),
+        appkey_add=dict(app_key_index=1, net_key_index=1, app_key=key,),
     )
 
 

--- a/bluetooth_mesh/messages/test/test_config.py
+++ b/bluetooth_mesh/messages/test/test_config.py
@@ -1089,7 +1089,7 @@ invalid_retr = [
 
 
 @pytest.mark.parametrize("message,encoded,decoded", invalid_retr)
-def test_build(message, encoded, decoded):
+def test_invalid_retransmit(message, encoded, decoded):
     _decoded = deepcopy(decoded)
     with pytest.raises(AttributeError):
         message.build(obj=_decoded)

--- a/bluetooth_mesh/messages/test/test_health.py
+++ b/bluetooth_mesh/messages/test/test_health.py
@@ -187,9 +187,13 @@ def test_build_invalid(message, decoded, exception):
         message.build(obj=decoded)
 
 
-def test_build_health_message():
+@pytest.mark.parametrize("key", ["params", "attention_set"])
+def test_build_health_message(key):
     data = HealthMessage.build(
-        dict(opcode=HealthOpcode.ATTENTION_SET, params=dict(attention=6))
+        {
+            "opcode": HealthOpcode.ATTENTION_SET,
+            key: dict(attention=6),
+        }
     )
 
     assert data == bytes.fromhex("800506")
@@ -198,7 +202,11 @@ def test_build_health_message():
 def test_parse_health_message():
     msg = HealthMessage.parse(bytes.fromhex("800506"))
 
-    assert msg == dict(opcode=HealthOpcode.ATTENTION_SET, params=dict(attention=6))
+    assert msg == dict(
+        opcode=HealthOpcode.ATTENTION_SET,
+        params=dict(attention=6),
+        attention_set=dict(attention=6),
+    )
 
 
 def test_parse_health_message_bad_opcode():

--- a/bluetooth_mesh/messages/test/test_sensor.py
+++ b/bluetooth_mesh/messages/test/test_sensor.py
@@ -94,8 +94,7 @@ valid = [
         [dict(sensor_setting_property_id=PropertyID.PRESENT_INPUT_CURRENT,
               length=2,
               format=0,
-              sensor_setting_raw=dict(
-                  current=2.0))],
+              present_input_current=dict(current=2.0))],
         id="SENSOR_STATUS_PRESENT_INPUT_CURRENT"),
     pytest.param(
         b'\x52\x22\x0b\x20\x03',
@@ -103,8 +102,8 @@ valid = [
         [dict(sensor_setting_property_id=PropertyID.PRESENT_INPUT_VOLTAGE,
               length=2,
               format=0,
-              sensor_setting_raw=dict(
-                  voltage=12.5))],
+              present_input_voltage=dict(voltage=12.5))
+        ],
         id="SENSOR_STATUS_PRESENT_INPUT_VOLTAGE"),
     pytest.param(
         b'\x52\x44\x0d\xa2\x44\xff',
@@ -112,8 +111,9 @@ valid = [
         [dict(sensor_setting_property_id=PropertyID.TOTAL_DEVICE_ENERGY_USE,
               length=3,
               format=0,
-              sensor_setting_raw=dict(
-                  energy=0xff44a2))],
+              total_device_energy_use=dict(
+                  energy=0xff44a2))
+        ],
         id="SENSOR_STATUS_TOTAL_DEVICE_ENERGY_USE"),
     pytest.param(
         b'\x52\x09\x90\x40\xa2\x44\xff\x00\x00',
@@ -121,7 +121,8 @@ valid = [
         [dict(sensor_setting_property_id=0x4090,
               length=5,
               format=1,
-              sensor_setting_raw=list(b'\xa2\x44\xff\x00\x00'))],
+              raw=list(b'\xa2\x44\xff\x00\x00'))
+        ],
         id="SENSOR_STATUS_VENDOR_PROPERTY"),
     pytest.param(
         b'\x52\x44\x0d\xa2\x44\xff\x22\x0b\x20\x03',
@@ -129,13 +130,11 @@ valid = [
         [dict(sensor_setting_property_id=PropertyID.TOTAL_DEVICE_ENERGY_USE,
               length=3,
               format=0,
-              sensor_setting_raw=dict(
-                  energy=0xff44a2)),
+              total_device_energy_use=dict(energy=0xff44a2)),
          dict(sensor_setting_property_id=PropertyID.PRESENT_INPUT_VOLTAGE,
               length=2,
               format=0,
-              sensor_setting_raw=dict(
-                  voltage=12.5))
+              present_input_voltage=dict(voltage=12.5))
          ],
         id="SENSOR_STATUS_2_SHORT_PROP"),
     # fmt: on

--- a/bluetooth_mesh/messages/test/test_sensor.py
+++ b/bluetooth_mesh/messages/test/test_sensor.py
@@ -121,7 +121,7 @@ valid = [
         [dict(sensor_setting_property_id=0x4090,
               length=5,
               format=1,
-              raw=list(b'\xa2\x44\xff\x00\x00'))
+              sensor_setting_raw=list(b'\xa2\x44\xff\x00\x00'))
         ],
         id="SENSOR_STATUS_VENDOR_PROPERTY"),
     pytest.param(
@@ -718,3 +718,25 @@ def test_build_valid_property(encoded, data):
         )
         == encoded
     )
+
+
+def test_parse_sensor_setting_raw():
+    sensor_status = SensorMessage.parse(b"\x52\xe2\x0a\xc8\x00").params[0]
+    assert sensor_status.sensor_setting_raw == sensor_status.present_input_current
+
+
+def test_build_sensor_setting_raw():
+    encoded = SensorMessage.build(
+        dict(
+            opcode=SensorOpcode.SENSOR_STATUS,
+            params=[
+                dict(
+                    sensor_setting_property_id=PropertyID.PRESENT_INPUT_CURRENT,
+                    length=2,
+                    format=0,
+                    sensor_setting_raw=dict(current=2.0),
+                )
+            ],
+        )
+    )
+    assert encoded == b"\x52\xe2\x0a\xc8\x00"

--- a/bluetooth_mesh/messages/test/test_sensor.py
+++ b/bluetooth_mesh/messages/test/test_sensor.py
@@ -155,13 +155,13 @@ valid_setup = [
         SensorSetupOpcode.SENSOR_SETTINGS_STATUS,
         dict(sensor_property_id=PropertyID.LIGHT_CONTROL_LIGHTNESS_STANDBY,
              sensor_setting_property_ids=[]),
-        id="SENSOR_SETTING_SET_empty"),
+        id="SENSOR_SETTING_STATUS_empty"),
     pytest.param(
         b'\x59\x57\x00\x57\x00\xc8\x00',
         SensorSetupOpcode.SENSOR_SETTING_SET,
         dict(sensor_property_id=PropertyID.PRESENT_INPUT_CURRENT,
              sensor_setting_property_id=PropertyID.PRESENT_INPUT_CURRENT,
-             sensor_setting_raw=dict(
+             present_input_current=dict(
                  current=2.0)),
         id="SENSOR_SETTING_SET"),
     pytest.param(
@@ -170,7 +170,7 @@ valid_setup = [
         dict(sensor_property_id=PropertyID.PRESENT_INPUT_CURRENT,
              sensor_setting_property_id=PropertyID.PRESENT_INPUT_CURRENT,
              sensor_setting_access=SensorSettingAccess.READ_ONLY,
-             sensor_setting_raw=dict(
+             present_input_current=dict(
                  current=2.0)),
         id="SENSOR_SETTING_STATUS"),
     pytest.param(
@@ -179,7 +179,7 @@ valid_setup = [
         dict(sensor_property_id=PropertyID.PRESENT_INPUT_CURRENT,
              sensor_setting_property_id=PropertyID.AVERAGE_INPUT_CURRENT,
              sensor_setting_access=SensorSettingAccess.READ_ONLY,
-             sensor_setting_raw=dict(
+             average_input_current=dict(
                  electric_current_value=2.0,
                  sensing_duration=dict(seconds=0.5132))),
         id="SENSOR_SETTING_STATUS"),
@@ -192,14 +192,14 @@ valid_properties = [
         b'\x59\x57\x00\x57\x00\xc8\x00',
         dict(sensor_property_id=PropertyID.PRESENT_INPUT_CURRENT,
              sensor_setting_property_id=PropertyID.PRESENT_INPUT_CURRENT,
-             sensor_setting_raw=dict(
+             present_input_current=dict(
                  current=2.0)),
         id="ElectricCurrent"),
     pytest.param(
         b'\x59\x57\x00\x02\x00\xc8\x00\x39',
         dict(sensor_property_id=PropertyID.PRESENT_INPUT_CURRENT,
              sensor_setting_property_id=PropertyID.AVERAGE_INPUT_CURRENT,
-             sensor_setting_raw=dict(
+             average_input_current=dict(
                  electric_current_value=2.0,
                  sensing_duration=dict(seconds=0.5132))),
         id="AverageCurrent"),
@@ -207,7 +207,7 @@ valid_properties = [
         b'\x59\x05\x00\x05\x00\x20\x03\x54',
         dict(sensor_property_id=PropertyID.AVERAGE_OUTPUT_VOLTAGE,
              sensor_setting_property_id=PropertyID.AVERAGE_OUTPUT_VOLTAGE,
-             sensor_setting_raw=dict(
+             average_output_voltage=dict(
                  voltage_value=12.5,
                  sensing_duration=dict(seconds=6.7275))),
         id="AverageVoltage"),
@@ -215,7 +215,7 @@ valid_properties = [
         b'\x59\x57\x00\x02\x00\xc8\x00\x00',
         dict(sensor_property_id=PropertyID.PRESENT_INPUT_CURRENT,
              sensor_setting_property_id=PropertyID.AVERAGE_INPUT_CURRENT,
-             sensor_setting_raw=dict(
+             average_input_current=dict(
                  electric_current_value=2.0,
                  sensing_duration=dict(seconds=0))),
         id="AverageCurrent_with_0"),
@@ -223,84 +223,84 @@ valid_properties = [
         b'\x59\x59\x00\x59\x00\x00\x03',
         dict(sensor_property_id=PropertyID.PRESENT_INPUT_VOLTAGE,
              sensor_setting_property_id=PropertyID.PRESENT_INPUT_VOLTAGE,
-             sensor_setting_raw=dict(
+             present_input_voltage=dict(
                  voltage=12)),
         id="Voltage"),
     pytest.param(
         b'\x59\x42\x00\x4d\x00\x01',
         dict(sensor_property_id=PropertyID.MOTION_SENSED,
              sensor_setting_property_id=PropertyID.PRESENCE_DETECTED,
-             sensor_setting_raw=dict(
+             presence_detected=dict(
                  presence_detected=True)),
         id="Presence"),
     pytest.param(
         b'\x59\x42\x00\x42\x00\x50',
         dict(sensor_property_id=PropertyID.MOTION_SENSED,
              sensor_setting_property_id=PropertyID.MOTION_SENSED,
-             sensor_setting_raw=dict(
+             motion_sensed=dict(
                  percentage=40)),
         id="Percentage8"),
     pytest.param(
         b'\x59\x0a\x00\x36\x00\xb8\x0b\x00',
         dict(sensor_property_id=PropertyID.DEVICE_APPEARANCE,
              sensor_setting_property_id=PropertyID.LIGHT_CONTROL_TIME_FADE,
-             sensor_setting_raw=dict(
+             light_control_time_fade=dict(
                  seconds=3)),
         id="TimeMiliseconds24"),
     pytest.param(
         b'\x59\x6d\x00\x6d\x00\x0a\x00\x00',
         dict(sensor_property_id=PropertyID.TOTAL_DEVICE_POWER_ON_TIME,
              sensor_setting_property_id=PropertyID.TOTAL_DEVICE_POWER_ON_TIME,
-             sensor_setting_raw=dict(
+             total_device_power_on_time=dict(
                  hours=10)),
         id="TimeHour24"),
     pytest.param(
         b'\x59\x6d\x00\x6d\x00\xff\xff\xff',
         dict(sensor_property_id=PropertyID.TOTAL_DEVICE_POWER_ON_TIME,
              sensor_setting_property_id=PropertyID.TOTAL_DEVICE_POWER_ON_TIME,
-             sensor_setting_raw=dict(
+             total_device_power_on_time=dict(
                  hours=None)),
         id="TimeHour24_unknown"),
     pytest.param(
         b'\x59\x55\x00\x55\x00\x1a\x27\x00',
         dict(sensor_property_id=PropertyID.PRESENT_ILLUMINANCE,
              sensor_setting_property_id=PropertyID.PRESENT_ILLUMINANCE,
-             sensor_setting_raw=dict(
+             present_illuminance=dict(
                  illuminance=100.1)),
         id="Illuminance"),
     pytest.param(
         b'\x59\x4c\x00\x4c\x00\x1b\x1a',
         dict(sensor_property_id=PropertyID.PEOPLE_COUNT,
              sensor_setting_property_id=PropertyID.PEOPLE_COUNT,
-             sensor_setting_raw=dict(
+             people_count=dict(
                  count=0x1a1b)),
         id="Count16"),
     pytest.param(
         b'\x59\x6c\x00\x6c\x00\xff\x1b\x1a',
         dict(sensor_property_id=PropertyID.TOTAL_DEVICE_POWER_ON_CYCLES,
              sensor_setting_property_id=PropertyID.TOTAL_DEVICE_POWER_ON_CYCLES,
-             sensor_setting_raw=dict(
+             total_device_power_on_cycles=dict(
                  count=0x1a1bff)),
         id="Count24"),
     pytest.param(
         b'\x59\x6c\x00\x6c\x00\xff\xff\xff',
         dict(sensor_property_id=PropertyID.TOTAL_DEVICE_POWER_ON_CYCLES,
              sensor_setting_property_id=PropertyID.TOTAL_DEVICE_POWER_ON_CYCLES,
-             sensor_setting_raw=dict(
+             total_device_power_on_cycles=dict(
                  count=None)),
         id="Count24_unknown"),
     pytest.param(
         b'\x59\x68\x00\x68\x00\x05\x00',
         dict(sensor_property_id=PropertyID.TIME_SINCE_MOTION_SENSED,
              sensor_setting_property_id=PropertyID.TIME_SINCE_MOTION_SENSED,
-             sensor_setting_raw=dict(
+             time_since_motion_sensed=dict(
                  seconds=5)),
         id="TimeSecond16"),
     pytest.param(
         b'\x59\x67\x00\x67\x00\x05\x00\x01\x00\x70\x40',
         dict(sensor_property_id=PropertyID.SHORT_CIRCUIT_EVENT_STATISTICS,
              sensor_setting_property_id=PropertyID.SHORT_CIRCUIT_EVENT_STATISTICS,
-             sensor_setting_raw=dict(
+             short_circuit_event_statistics=dict(
                  number_of_events=dict(count=5),
                  average_event_duration=dict(seconds=1),
                  time_elapsed_since_last_event=dict(seconds=97.0172),
@@ -311,28 +311,28 @@ valid_properties = [
         b'\x59\x0e\x00\x0e\x00abcdefgh',
         dict(sensor_property_id=PropertyID.DEVICE_FIRMWARE_REVISION,
              sensor_setting_property_id=PropertyID.DEVICE_FIRMWARE_REVISION,
-             sensor_setting_raw='abcdefgh',
+             device_firmware_revision="abcdefgh",
              ),
         id="FixedString8"),
     pytest.param(
         b'\x59\x0e\x00\x0e\x00abcdef\x00\x00',
         dict(sensor_property_id=PropertyID.DEVICE_FIRMWARE_REVISION,
              sensor_setting_property_id=PropertyID.DEVICE_FIRMWARE_REVISION,
-             sensor_setting_raw='abcdef',
+             device_firmware_revision='abcdef',
              ),
         id="FixedString8_padded"),
     pytest.param(
         b'\x59\x11\x00\x11\x00abcdefghabcdefghabcdefghabcdefghabcd',
         dict(sensor_property_id=PropertyID.DEVICE_MANUFACTURER_NAME,
              sensor_setting_property_id=PropertyID.DEVICE_MANUFACTURER_NAME,
-             sensor_setting_raw='abcdefghabcdefghabcdefghabcdefghabcd',
+             device_manufacturer_name='abcdefghabcdefghabcdefghabcdefghabcd',
              ),
         id="FixedString36"),
     pytest.param(
         b'\x59\x6a\x00\x6a\x00\xa2\x44\xff',
         dict(sensor_property_id=PropertyID.TOTAL_DEVICE_ENERGY_USE,
              sensor_setting_property_id=PropertyID.TOTAL_DEVICE_ENERGY_USE,
-             sensor_setting_raw=dict(
+             total_device_energy_use=dict(
                  energy=0xff44a2
              )),
         id="Energy"),
@@ -340,7 +340,7 @@ valid_properties = [
         b'\x59\x2e\x00\x2e\x00\x44\xff',
         dict(sensor_property_id=PropertyID.LIGHT_CONTROL_LIGHTNESS_ON,
              sensor_setting_property_id=PropertyID.LIGHT_CONTROL_LIGHTNESS_ON,
-             sensor_setting_raw=dict(
+             light_control_lightness_on=dict(
                  perceived_lightness=0xff44
              )),
         id="PerceivedLightness"),
@@ -348,7 +348,7 @@ valid_properties = [
         b'\x59\x32\x00\x32\x00\x44\xff\x00\x00',
         dict(sensor_property_id=PropertyID.LIGHT_CONTROL_REGULATOR_KID,
              sensor_setting_property_id=PropertyID.LIGHT_CONTROL_REGULATOR_KID,
-             sensor_setting_raw=dict(
+             light_control_regulator_kid=dict(
                  coefficient=0x0000ff44
              )),
         id="Coefficient"),
@@ -356,7 +356,7 @@ valid_properties = [
         b'\x59\x52\x00\x52\x00\xa0\x86\x01',
         dict(sensor_property_id=PropertyID.PRESENT_DEVICE_INPUT_POWER,
              sensor_setting_property_id=PropertyID.PRESENT_DEVICE_INPUT_POWER,
-             sensor_setting_raw=dict(
+             present_device_input_power=dict(
                  power=10000
              )),
         id="Power"),
@@ -364,7 +364,7 @@ valid_properties = [
         b'\x59\x16\x00\x16\x00\xe8\x03\x00\xd0\x07\x00\x0f\x27\x00',
         dict(sensor_property_id=PropertyID.DEVICE_POWER_RANGE_SPECIFICATION,
              sensor_setting_property_id=PropertyID.DEVICE_POWER_RANGE_SPECIFICATION,
-             sensor_setting_raw=dict(
+             device_power_range_specification=dict(
                  minimum_power_value=100,
                  typical_power_value=200,
                  maximum_power_value=999.9,
@@ -374,7 +374,7 @@ valid_properties = [
         b'\x59\x4f\x00\x4f\x00\x1f',
         dict(sensor_property_id=PropertyID.PRESENT_AMBIENT_TEMPERATURE,
              sensor_setting_property_id=PropertyID.PRESENT_AMBIENT_TEMPERATURE,
-             sensor_setting_raw=dict(
+             present_ambient_temperature=dict(
                  temperature=15.5,
              )),
         id="Temperature8_positive"),
@@ -382,7 +382,7 @@ valid_properties = [
         b'\x59\x4f\x00\x4f\x00\xe1',
         dict(sensor_property_id=PropertyID.PRESENT_AMBIENT_TEMPERATURE,
              sensor_setting_property_id=PropertyID.PRESENT_AMBIENT_TEMPERATURE,
-             sensor_setting_raw=dict(
+             present_ambient_temperature=dict(
                  temperature=-15.5,
              )),
         id="Temperature8_negative"),
@@ -390,7 +390,7 @@ valid_properties = [
         b'\x59\x54\x00\x54\x00\xe6\x20',
         dict(sensor_property_id=PropertyID.PRESENT_DEVICE_OPERATING_TEMPERATURE,
              sensor_setting_property_id=PropertyID.PRESENT_DEVICE_OPERATING_TEMPERATURE,
-             sensor_setting_raw=dict(
+             present_device_operating_temperature=dict(
                  temperature=84.22,
              )),
         id="Temperature_positive"),
@@ -398,7 +398,7 @@ valid_properties = [
         b'\x59\x45\x00\x45\x00\x31\x02\xdc\x6e\x71',
         dict(sensor_property_id=PropertyID.OUTDOOR_STATISTICAL_VALUES,
              sensor_setting_property_id=PropertyID.OUTDOOR_STATISTICAL_VALUES,
-             sensor_setting_raw=dict(
+             outdoor_statistical_values=dict(
                  average_temperature=24.5,
                  standard_deviation_temperature=1,
                  minimum_temperature=-18,
@@ -410,7 +410,7 @@ valid_properties = [
         b'\x59\x14\x00\x14\x00\x92\x09\x64\x00\xf8\xf8\x20\x4e\x71',
         dict(sensor_property_id=PropertyID.DEVICE_OPERATING_TEMPERATURE_STATISTICAL_VALUES,
              sensor_setting_property_id=PropertyID.DEVICE_OPERATING_TEMPERATURE_STATISTICAL_VALUES,
-             sensor_setting_raw=dict(
+             device_operating_temperature_statistical_values=dict(
                  average_temperature=24.5,
                  standard_deviation_temperature=1,
                  minimum_temperature=-18,
@@ -422,7 +422,7 @@ valid_properties = [
         b'\x59\x13\x00\x13\x00\xdc\x6e',
         dict(sensor_property_id=PropertyID.DEVICE_OPERATING_TEMPERATURE_RANGE_SPECIFICATION,
              sensor_setting_property_id=PropertyID.DEVICE_OPERATING_TEMPERATURE_RANGE_SPECIFICATION,
-             sensor_setting_raw=dict(
+             device_operating_temperature_range_specification=dict(
                  minimum_temperature=-18,
                  maximum_temperature=55,
              )),
@@ -431,7 +431,7 @@ valid_properties = [
         b'\x59\x01\x00\x01\x00\x18\x6d\xa2',
         dict(sensor_property_id=PropertyID.AVERAGE_AMBIENT_TEMPERATURE_IN_A_PERIOD_OF_DAY,
              sensor_setting_property_id=PropertyID.AVERAGE_AMBIENT_TEMPERATURE_IN_A_PERIOD_OF_DAY,
-             sensor_setting_raw=dict(
+             average_ambient_temperature_in_a_period_of_day=dict(
                  temperature=12,
                  start_time=dict(hour=10.9),
                  end_time=dict(hour=16.2),
@@ -441,7 +441,7 @@ valid_properties = [
         b'\x59\x60\x00\x60\x00\xa2\x44\xff\x6d\xa2',
         dict(sensor_property_id=PropertyID.RELATIVE_DEVICE_ENERGY_USE_IN_A_PERIOD_OF_DAY,
              sensor_setting_property_id=PropertyID.RELATIVE_DEVICE_ENERGY_USE_IN_A_PERIOD_OF_DAY,
-             sensor_setting_raw=dict(
+             relative_device_energy_use_in_a_period_of_day=dict(
                  energy_value=0xff44a2,
                  start_time=dict(hour=10.9),
                  end_time=dict(hour=16.2),
@@ -451,7 +451,7 @@ valid_properties = [
         b'\x59\x2a\x00\x2a\x00\x69\x01\x40\x00\x00\x00\xf0\xff\x54',
         dict(sensor_property_id=PropertyID.INPUT_VOLTAGE_STATISTICS,
              sensor_setting_property_id=PropertyID.INPUT_VOLTAGE_STATISTICS,
-             sensor_setting_raw=dict(
+             input_voltage_statistics=dict(
                  average_voltage_value=5.640625,
                  standard_deviation_voltage_value=1,
                  minimum_voltage_value=0,
@@ -463,7 +463,7 @@ valid_properties = [
         b'\x59\x49\x00\x49\x00\x00\x00\x00\x06\xf0\xff',
         dict(sensor_property_id=PropertyID.OUTPUT_VOLTAGE_RANGE,
              sensor_setting_property_id=PropertyID.OUTPUT_VOLTAGE_RANGE,
-             sensor_setting_raw=dict(
+             output_voltage_range=dict(
                  minimum_voltage_value=0,
                  typical_voltage_value=24,
                  maximum_voltage_value=1023.75,
@@ -473,7 +473,7 @@ valid_properties = [
         b'\x59\x47\x00\x47\x00\x97\x09\x64\x00\x00\x00\x7d\x15\x71',
         dict(sensor_property_id=PropertyID.OUTPUT_CURRENT_STATISTICS,
              sensor_setting_property_id=PropertyID.OUTPUT_CURRENT_STATISTICS,
-             sensor_setting_raw=dict(
+             output_current_statistics=dict(
                  average_electric_current_value=24.55,
                  standard_deviation_electric_current_value=1,
                  minimum_electric_current_value=0,
@@ -485,7 +485,7 @@ valid_properties = [
         b'\x59\x46\x00\x46\x00\x00\x00\x7d\x15',
         dict(sensor_property_id=PropertyID.OUTPUT_CURRENT_RANGE,
              sensor_setting_property_id=PropertyID.OUTPUT_CURRENT_RANGE,
-             sensor_setting_raw=dict(
+             output_current_range=dict(
                  minimum_electric_current_value=0,
                  maximum_electric_current_value=55.01,
              )),
@@ -494,7 +494,7 @@ valid_properties = [
         b'\x59\x21\x00\x21\x00\x00\x00\x01\x00\x7d\x15',
         dict(sensor_property_id=PropertyID.INPUT_CURRENT_RANGE_SPECIFICATION,
              sensor_setting_property_id=PropertyID.INPUT_CURRENT_RANGE_SPECIFICATION,
-             sensor_setting_raw=dict(
+                     input_current_range_specification=dict(
                  minimum_electric_current_value=0,
                  typical_electric_current_value=0.01,
                  maximum_electric_current_value=55.01,
@@ -504,7 +504,7 @@ valid_properties = [
         b'\x59\x70\x00\x70\x00\x02\x00\x00',
         dict(sensor_property_id=PropertyID.TOTAL_LUMINOUS_ENERGY,
              sensor_setting_property_id=PropertyID.TOTAL_LUMINOUS_ENERGY,
-             sensor_setting_raw=dict(
+             total_luminous_energy=dict(
                  luminous_energy=2000,
              )),
         id="LuminousEnergy"),
@@ -512,7 +512,7 @@ valid_properties = [
         b'\x59\x06\x00\x06\x00\x00\x20',
         dict(sensor_property_id=PropertyID.CENTER_BEAM_INTENSITY_AT_FULL_POWER,
              sensor_setting_property_id=PropertyID.CENTER_BEAM_INTENSITY_AT_FULL_POWER,
-             sensor_setting_raw=dict(
+             center_beam_intensity_at_full_power=dict(
                  luminous_intensity=0x2000,
              )),
         id="LuminousIntensity"),
@@ -520,7 +520,7 @@ valid_properties = [
         b'\x59\x40\x00\x40\x00\x02\x00\x00',
         dict(sensor_property_id=PropertyID.LUMINOUS_EXPOSURE,
              sensor_setting_property_id=PropertyID.LUMINOUS_EXPOSURE,
-             sensor_setting_raw=dict(
+             luminous_exposure=dict(
                  luminous_exposure=2000,
              )),
         id="LuminousExposure"),
@@ -528,7 +528,7 @@ valid_properties = [
         b'\x59\x1f\x00\x1f\x00\xd0\x07',
         dict(sensor_property_id=PropertyID.INITIAL_LUMINOUS_FLUX,
              sensor_setting_property_id=PropertyID.INITIAL_LUMINOUS_FLUX,
-             sensor_setting_raw=dict(
+             initial_luminous_flux=dict(
                  luminous_flux=2000,
              )),
         id="LuminousFlux"),
@@ -536,7 +536,7 @@ valid_properties = [
         b'\x59\x41\x00\x41\x00\xe8\x03\xd0\x07',
         dict(sensor_property_id=PropertyID.LUMINOUS_FLUX_RANGE,
              sensor_setting_property_id=PropertyID.LUMINOUS_FLUX_RANGE,
-             sensor_setting_raw=dict(
+             luminous_flux_range=dict(
                  minimum_luminous_flux=1000,
                  maximum_luminous_flux=2000,
              )),
@@ -545,7 +545,7 @@ valid_properties = [
         b'\x59\x3e\x00\x3e\x00\xd4\x07',
         dict(sensor_property_id=PropertyID.LUMINOUS_EFFICACY,
              sensor_setting_property_id=PropertyID.LUMINOUS_EFFICACY,
-             sensor_setting_raw=dict(
+             luminous_efficacy=dict(
                  luminous_efficacy=200.4,
              )),
         id="LuminousEfficacy"),
@@ -553,7 +553,7 @@ valid_properties = [
         b'\x59\x0f\x00\x0f\x00\xff\xee\xdd\xcc\xbb\xaa',
         dict(sensor_property_id=PropertyID.DEVICE_GLOBAL_TRADE_ITEM_NUMBER,
              sensor_setting_property_id=PropertyID.DEVICE_GLOBAL_TRADE_ITEM_NUMBER,
-             sensor_setting_raw=dict(
+             device_global_trade_item_number=dict(
                  global_trade_item_number=0xaabbccddeeff
              )),
         id="GlobalTradeItemNumber"),
@@ -561,7 +561,7 @@ valid_properties = [
         b'\x59\x07\x00\x07\x00\x64',
         dict(sensor_property_id=PropertyID.CHROMATICITY_TOLERANCE,
              sensor_setting_property_id=PropertyID.CHROMATICITY_TOLERANCE,
-             sensor_setting_raw=dict(
+             chromaticity_tolerance=dict(
                  chromaticity_tolerance=0.01,
              )),
         id="ChromaticityTolerance"),
@@ -569,7 +569,7 @@ valid_properties = [
         b'\x59\x5e\x00\x5e\x00\x92\x27',
         dict(sensor_property_id=PropertyID.PRESENT_PLANCKIAN_DISTANCE,
              sensor_setting_property_id=PropertyID.PRESENT_PLANCKIAN_DISTANCE,
-             sensor_setting_raw=dict(
+             present_planckian_distance=dict(
                  distance_from_planckian=0.1013,
              )),
         id="ChromaticDistanceFromPlanckian"),
@@ -577,7 +577,7 @@ valid_properties = [
         b'\x59\x51\x00\x51\x00\xb8\x0b',
         dict(sensor_property_id=PropertyID.PRESENT_CORRELATED_COLOR_TEMPERATURE,
              sensor_setting_property_id=PropertyID.PRESENT_CORRELATED_COLOR_TEMPERATURE,
-             sensor_setting_raw=dict(
+             present_correlated_color_temperature=dict(
                  correlated_color_temperature=3000,
              )),
         id="CorrelatedColorTemperature"),
@@ -585,7 +585,7 @@ valid_properties = [
         b'\x59\x0a\x00\x0a\x00\x04\xf0',
         dict(sensor_property_id=PropertyID.DEVICE_APPEARANCE,
              sensor_setting_property_id=PropertyID.DEVICE_APPEARANCE,
-             sensor_setting_raw=dict(
+             device_appearance=dict(
                  category=960,
                  sub_category=4
              )),
@@ -594,7 +594,7 @@ valid_properties = [
         b'\x59\x0b\x00\x0b\x00\x2a\x00',
         dict(sensor_property_id=PropertyID.DEVICE_COUNTRY_OF_ORIGIN,
              sensor_setting_property_id=PropertyID.DEVICE_COUNTRY_OF_ORIGIN,
-             sensor_setting_raw=dict(
+             device_country_of_origin=dict(
                  country_code=42,
              )),
         id="CountryCode"),
@@ -602,15 +602,15 @@ valid_properties = [
         b'\x59\x0c\x00\x0c\x00\xde\x46\x00',
         dict(sensor_property_id=PropertyID.DEVICE_DATE_OF_MANUFACTURE,
              sensor_setting_property_id=PropertyID.DEVICE_DATE_OF_MANUFACTURE,
-             sensor_setting_raw=dict(
+             device_date_of_manufacture=dict(
                  date=datetime(2019, 9, 3),
              )),
         id="DateUTC"),
     pytest.param(
         b'\x59\x50\x00\x50\x00\xee\x00\xcd\xab',
-        dict(sensor_property_id=PropertyID.PRESENT_CIE_1931_CHROMATICITY_COORDINATES,
-             sensor_setting_property_id=PropertyID.PRESENT_CIE_1931_CHROMATICITY_COORDINATES,
-             sensor_setting_raw=dict(
+        dict(sensor_property_id=PropertyID.PRESENT_CIE1931_CHROMATICITY_COORDINATES,
+             sensor_setting_property_id=PropertyID.PRESENT_CIE1931_CHROMATICITY_COORDINATES,
+             present_cie1931_chromaticity_coordinates=dict(
                  chromaticity_x_coordinate=0xee/0xffff,
                  chromaticity_y_coordinate=0xabcd/0xffff,
              )),
@@ -619,7 +619,7 @@ valid_properties = [
         b'\x59\x08\x00\x08\x00\x64',
         dict(sensor_property_id=PropertyID.COLOR_RENDERING_INDEX_R9,
              sensor_setting_property_id=PropertyID.COLOR_RENDERING_INDEX_R9,
-             sensor_setting_raw=dict(
+             color_rendering_index_r9=dict(
                  color_rendering_index=100,
              )),
         id="ColorRenderingIndex_positive"),
@@ -627,7 +627,7 @@ valid_properties = [
         b'\x59\x08\x00\x08\x00\x9c',
         dict(sensor_property_id=PropertyID.COLOR_RENDERING_INDEX_R9,
              sensor_setting_property_id=PropertyID.COLOR_RENDERING_INDEX_R9,
-             sensor_setting_raw=dict(
+             color_rendering_index_r9=dict(
                  color_rendering_index=-100,
              )),
         id="ColorRenderingIndex_negative"),
@@ -635,7 +635,7 @@ valid_properties = [
         b'\x59\x61\x00\x61\x00\x88\xaa\x00\xbb\xbb',
         dict(sensor_property_id=PropertyID.RELATIVE_DEVICE_RUNTIME_IN_A_GENERIC_LEVEL_RANGE,
              sensor_setting_property_id=PropertyID.RELATIVE_DEVICE_RUNTIME_IN_A_GENERIC_LEVEL_RANGE,
-             sensor_setting_raw=dict(
+             relative_device_runtime_in_a_generic_level_range=dict(
                  relative_value=0x44,
                  minimum_generic_level=0xaa,
                  maximum_generic_level=0xbbbb,
@@ -645,7 +645,7 @@ valid_properties = [
         b'\x59\x62\x00\x62\x00\x88\x1a\x27\x00\x1a\x27\x00',
         dict(sensor_property_id=PropertyID.RELATIVE_EXPOSURE_TIME_IN_AN_ILLUMINANCE_RANGE,
              sensor_setting_property_id=PropertyID.RELATIVE_EXPOSURE_TIME_IN_AN_ILLUMINANCE_RANGE,
-             sensor_setting_raw=dict(
+             relative_exposure_time_in_an_illuminance_range=dict(
                  relative_value=0x44,
                  minimum_illuminance=100.1,
                  maximum_illuminance=100.1,
@@ -655,7 +655,7 @@ valid_properties = [
         b'\x59\x64\x00\x64\x00\x88\xff\xff\xe6\x20',
         dict(sensor_property_id=PropertyID.RELATIVE_RUNTIME_IN_A_DEVICE_OPERATING_TEMPERATURE_RANGE,
              sensor_setting_property_id=PropertyID.RELATIVE_RUNTIME_IN_A_DEVICE_OPERATING_TEMPERATURE_RANGE,
-             sensor_setting_raw=dict(
+             relative_runtime_in_a_device_operating_temperature_range=dict(
                  relative_value=0x44,
                  minimum_temperature=-0.01,
                  maximum_temperature=84.22,
@@ -665,7 +665,7 @@ valid_properties = [
         b'\x59\x65\x00\x65\x00\x88\x00\x00\xcd\xab',
         dict(sensor_property_id=PropertyID.RELATIVE_RUNTIME_IN_AN_INPUT_CURRENT_RANGE,
              sensor_setting_property_id=PropertyID.RELATIVE_RUNTIME_IN_AN_INPUT_CURRENT_RANGE,
-             sensor_setting_raw=dict(
+             relative_runtime_in_an_input_current_range=dict(
                  relative_value=0x44,
                  minimum_current=0,
                  maximum_current=439.81,
@@ -675,7 +675,7 @@ valid_properties = [
         b'\x59\x66\x00\x66\x00\x88\x20\x03\x20\x03',
         dict(sensor_property_id=PropertyID.RELATIVE_RUNTIME_IN_AN_INPUT_VOLTAGE_RANGE,
              sensor_setting_property_id=PropertyID.RELATIVE_RUNTIME_IN_AN_INPUT_VOLTAGE_RANGE,
-             sensor_setting_raw=dict(
+             relative_runtime_in_an_input_voltage_range=dict(
                  relative_value=0x44,
                  minimum_voltage=12.5,
                  maximum_voltage=12.5

--- a/bluetooth_mesh/messages/time.py
+++ b/bluetooth_mesh/messages/time.py
@@ -36,12 +36,18 @@ from construct import (
     Select,
     StopIf,
     Struct,
+    Switch,
     stream_read,
     stream_write,
     this,
 )
 
-from bluetooth_mesh.messages.util import EmbeddedBitStruct, EnumAdapter, OpcodeMessage
+from bluetooth_mesh.messages.util import (
+    EmbeddedBitStruct,
+    EnumAdapter,
+    Opcode,
+    SwitchStruct,
+)
 
 MS_IN_UNCERTAINTY_STEP = 10
 UNCERTAINTY_MS = 10
@@ -219,17 +225,24 @@ class TimeOpcode(enum.IntEnum):
 
 
 # fmt: off
-TimeMessage = OpcodeMessage({
-    TimeOpcode.TIME_GET: TimeGet,
-    TimeOpcode.TIME_SET: TimeSet,
-    TimeOpcode.TIME_STATUS: TimeStatus,
-    TimeOpcode.TIME_ZONE_GET: TimeZoneGet,
-    TimeOpcode.TIME_ZONE_SET: TimeZoneSet,
-    TimeOpcode.TIME_ZONE_STATUS: TimeZoneStatus,
-    TimeOpcode.TAI_UTC_DELTA_GET: TAIUTCDeltaGet,
-    TimeOpcode.TAI_UTC_DELTA_SET: TAIUTCDeltaSet,
-    TimeOpcode.TAI_UTC_DELTA_STATUS: TAIUTCDeltaStatus,
-    TimeOpcode.TIME_ROLE_GET: TimeRoleGet,
-    TimeOpcode.TIME_ROLE_SET: TimeRoleSet,
-    TimeOpcode.TIME_ROLE_STATUS: TimeRoleStatus})
+TimeMessage = SwitchStruct(
+    "opcode" / Opcode(TimeOpcode),
+    "params" / Switch(
+        this.opcode,
+        {
+            TimeOpcode.TIME_GET: TimeGet,
+            TimeOpcode.TIME_SET: TimeSet,
+            TimeOpcode.TIME_STATUS: TimeStatus,
+            TimeOpcode.TIME_ZONE_GET: TimeZoneGet,
+            TimeOpcode.TIME_ZONE_SET: TimeZoneSet,
+            TimeOpcode.TIME_ZONE_STATUS: TimeZoneStatus,
+            TimeOpcode.TAI_UTC_DELTA_GET: TAIUTCDeltaGet,
+            TimeOpcode.TAI_UTC_DELTA_SET: TAIUTCDeltaSet,
+            TimeOpcode.TAI_UTC_DELTA_STATUS: TAIUTCDeltaStatus,
+            TimeOpcode.TIME_ROLE_GET: TimeRoleGet,
+            TimeOpcode.TIME_ROLE_SET: TimeRoleSet,
+            TimeOpcode.TIME_ROLE_STATUS: TimeRoleStatus
+        }
+    )
+)
 # fmt: on

--- a/bluetooth_mesh/messages/time.py
+++ b/bluetooth_mesh/messages/time.py
@@ -33,7 +33,6 @@ from construct import (
     Flag,
     Int8ul,
     Padding,
-    Select,
     StopIf,
     Struct,
     Switch,
@@ -47,6 +46,7 @@ from bluetooth_mesh.messages.util import (
     EnumAdapter,
     Opcode,
     SwitchStruct,
+    NamedSelect,
 )
 
 MS_IN_UNCERTAINTY_STEP = 10
@@ -123,7 +123,7 @@ TimeOptional = Struct(
     "time_zone_offset" / Int8ul,
 )
 
-Time = Select(
+Time = NamedSelect(
     optional=TimeOptional,
     minimal=TimeMinimal,
 )

--- a/bluetooth_mesh/messages/time.py
+++ b/bluetooth_mesh/messages/time.py
@@ -35,19 +35,14 @@ from construct import (
     Padding,
     StopIf,
     Struct,
-    Switch,
     stream_read,
     stream_write,
     this,
 )
 
-from bluetooth_mesh.messages.util import (
-    EmbeddedBitStruct,
-    EnumAdapter,
-    Opcode,
-    SwitchStruct,
-    NamedSelect,
-)
+from bluetooth_mesh.messages.util import EmbeddedBitStruct, EnumAdapter
+from bluetooth_mesh.messages.util import EnumSwitch as Switch
+from bluetooth_mesh.messages.util import NamedSelect, Opcode, SwitchStruct
 
 MS_IN_UNCERTAINTY_STEP = 10
 UNCERTAINTY_MS = 10

--- a/bluetooth_mesh/messages/time.py
+++ b/bluetooth_mesh/messages/time.py
@@ -40,7 +40,7 @@ from construct import (
     Flag,
 )
 
-from .util import EnumAdapter, EmbeddedBitStruct, OpcodeMessage
+from bluetooth_mesh.messages.util import EnumAdapter, EmbeddedBitStruct, OpcodeMessage
 
 MS_IN_UNCERTAINTY_STEP = 10
 UNCERTAINTY_MS = 10

--- a/bluetooth_mesh/messages/time.py
+++ b/bluetooth_mesh/messages/time.py
@@ -22,25 +22,26 @@
 import calendar
 import enum
 import time
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 
 from construct import (
-    Int8ul,
-    Struct,
+    Adapter,
     BitsInteger,
-    Padding,
     BytesInteger,
     Construct,
-    stream_read,
     Container,
-    stream_write,
-    Adapter,
-    StopIf,
-    this,
     Flag,
+    Int8ul,
+    Padding,
+    Select,
+    StopIf,
+    Struct,
+    stream_read,
+    stream_write,
+    this,
 )
 
-from bluetooth_mesh.messages.util import EnumAdapter, EmbeddedBitStruct, OpcodeMessage
+from bluetooth_mesh.messages.util import EmbeddedBitStruct, EnumAdapter, OpcodeMessage
 
 MS_IN_UNCERTAINTY_STEP = 10
 UNCERTAINTY_MS = 10
@@ -99,8 +100,11 @@ def subsecond_to_seconds(subsecond: int) -> float:
 def seconds_to_subsecond(seconds: float) -> int:
     return round((seconds - int(seconds)) * 256)
 
+TimeMinimal = Struct(
+    "tai_seconds" / BytesInteger(5, swapped=True),
+)
 
-Time = Struct(
+TimeOptional = Struct(
     "tai_seconds" / BytesInteger(5, swapped=True),
     StopIf(this.tai_seconds == 0),
     "subsecond" / Int8ul,
@@ -111,6 +115,11 @@ Time = Struct(
                        reversed=True
                        ),
     "time_zone_offset" / Int8ul,
+)
+
+Time = Select(
+    TimeOptional,
+    TimeMinimal,
 )
 
 

--- a/bluetooth_mesh/messages/time.py
+++ b/bluetooth_mesh/messages/time.py
@@ -118,8 +118,8 @@ TimeOptional = Struct(
 )
 
 Time = Select(
-    TimeOptional,
-    TimeMinimal,
+    optional=TimeOptional,
+    minimal=TimeMinimal,
 )
 
 

--- a/bluetooth_mesh/messages/util.py
+++ b/bluetooth_mesh/messages/util.py
@@ -39,6 +39,7 @@ from construct import (
     Int8ub,
     Int16ub,
     Int24ub,
+    Int32ub,
     Rebuild,
     Restreamed,
     Select,
@@ -212,6 +213,8 @@ def EmbeddedBitStruct(name, *fields, reversed=False):
 
 
 class Opcode(Construct):
+    subcon = Int32ub
+
     def __init__(self, type=int):
         super().__init__()
         self.type = type

--- a/bluetooth_mesh/messages/util.py
+++ b/bluetooth_mesh/messages/util.py
@@ -393,3 +393,18 @@ class SwitchStruct(Adapter):
             value = obj[self.switch.name]
 
         return Container({self.key.name: key, self.switch.name: value})
+
+
+class NameAdapter(Adapter):
+    def _decode(self, obj, context, path):
+        obj._name = self.subcon.name
+        return obj
+
+    def _encode(self, obj, context, path):
+        return obj.get(self.subcon.name, obj)
+
+
+class NamedSelect(Select):
+    def __init__(self, *subcons, **subconskw):
+        subcons = list(NameAdapter(k/v) for k,v in subconskw.items())
+        super().__init__(*subcons)

--- a/bluetooth_mesh/messages/util.py
+++ b/bluetooth_mesh/messages/util.py
@@ -35,6 +35,7 @@ from construct import (
     Embedded,
     Enum,
     ExprValidator,
+    Float32b,
     Int8ub,
     Int16ub,
     Int24ub,
@@ -100,6 +101,8 @@ def EnumAdapter(subcon, enum):
         ENUM = enum
 
     class _EnumAdapter(Adapter):
+        _subcon = subcon
+
         def _decode(self, obj, context, path):
             if obj not in enum._value2member_map_:
                 raise ValidationError("object failed validation: %s" % (obj,))
@@ -122,6 +125,7 @@ def EnumAdapter(subcon, enum):
 def LogAdapter(subcon, *, max_value=None, infinity=False):
     class _LogAdapter(Adapter):
         MAX_TYPE_VALUE = int(math.pow(2, subcon.length * 8) - 1)
+        _subcon = subcon
 
         def _decode(self, obj, context, path):
             if obj == 0:
@@ -255,6 +259,8 @@ class Opcode(Construct):
 
 
 class DefaultCountValidator(Adapter):
+    _subcon = Float32b
+
     def __init__(self, subcon, rounding=None, resolution=1.0):
         super().__init__(subcon)
         self.rounding = rounding

--- a/bluetooth_mesh/messages/util.py
+++ b/bluetooth_mesh/messages/util.py
@@ -340,6 +340,7 @@ class OpcodeMessage(Construct):
 
     def __init__(self, opcodes):
         super().__init__()
+        self._subcon = Struct("opcode" / Opcode(), "params" / Switch(this.opcode, opcodes))
         self.opcodes = {k: v.compile() for k, v in opcodes.items()}
 
     def _parse(self, stream, context, path):

--- a/bluetooth_mesh/models/base.py
+++ b/bluetooth_mesh/models/base.py
@@ -115,12 +115,11 @@ class Model:
         message: ParsedMeshMessage,
     ):
         self.logger.debug(
-            "App message received: %04x [app_index %d, destination %04x] opcode=%s params=%r",
+            "App message received: %04x [app_index %d, destination %04x] %r",
             source,
             app_index,
             destination,
-            message["opcode"],
-            message["params"],
+            message,
         )
 
         callbacks = self.app_message_callbacks[message["opcode"]]
@@ -143,12 +142,11 @@ class Model:
         self, source: int, remote: bool, net_index: int, message: ParsedMeshMessage
     ):
         self.logger.debug(
-            "Dev message received: %04x [remote %s, net_index %d] opcode=%s params=%r",
+            "Dev message received: %04x [remote %s, net_index %d] %r",
             source,
             remote,
             net_index,
-            message["opcode"],
-            message["params"],
+            message
         )
 
         callbacks = self.dev_message_callbacks[message["opcode"]]
@@ -280,12 +278,11 @@ class Model:
 
         message = AccessMessage.parse(data)
         self.logger.debug(
-            "Sending: %s -> %04x [app_index %d] %s %r",
+            "Sending: %s -> %04x [app_index %d] %r",
             self.element.path,
             destination,
             app_index,
-            message["opcode"],
-            message["params"],
+            message
         )
 
         await self._send_app(destination, app_index, data)
@@ -333,13 +330,12 @@ class Model:
 
         message = AccessMessage.parse(data)
         self.logger.debug(
-            "Sending: %s -> %04x [remote %s, net_index %d] %s %r",
+            "Sending: %s -> %04x [remote %s, net_index %d] %r",
             self.element.path,
             destination,
             remote,
             net_index,
-            message["opcode"],
-            message["params"],
+            message
         )
 
         await self._send_dev(destination, remote, net_index, data)

--- a/bluetooth_mesh/models/models.py
+++ b/bluetooth_mesh/models/models.py
@@ -749,7 +749,7 @@ class ConfigClient(Model):
         return ModelPublicationStatus(
             status["params"]["element_address"],
             status["params"]["publish_address"],
-            status["params"]["TTL"],
+            status["params"]["ttl"],
             status["params"]["app_key_index"],
             period,
             retransmissions,
@@ -764,7 +764,7 @@ class ConfigClient(Model):
         publication_address: int,
         app_key_index: int,
         model: Type[Model],
-        TTL: int = 8,
+        ttl: int = 8,
         publish_step_resolution: PublishPeriodStepResolution = PublishPeriodStepResolution.RESOLUTION_10_S,
         publish_number_of_steps: int = 6,  # 60seconds
         retransmit_count: int = 0,
@@ -779,7 +779,7 @@ class ConfigClient(Model):
                 status=StatusCode.SUCCESS,
                 element_address=element_address,
                 publish_address=publication_address,
-                TTL=TTL,
+                ttl=ttl,
                 app_key_index=app_key_index,
                 credential_flag=PublishFriendshipCredentialsFlag.MASTER_SECURITY,
                 RFU=0,
@@ -800,7 +800,7 @@ class ConfigClient(Model):
             params=dict(
                 element_address=element_address,
                 publish_address=publication_address,
-                TTL=TTL,
+                ttl=ttl,
                 app_key_index=app_key_index,
                 credential_flag=PublishFriendshipCredentialsFlag.MASTER_SECURITY,
                 RFU=0,
@@ -831,7 +831,7 @@ class ConfigClient(Model):
         return ModelPublicationStatus(
             status["params"]["element_address"],
             status["params"]["publish_address"],
-            status["params"]["TTL"],
+            status["params"]["ttl"],
             status["params"]["app_key_index"],
             period,
             retransmissions,

--- a/bluetooth_mesh/test/test_element.py
+++ b/bluetooth_mesh/test/test_element.py
@@ -26,6 +26,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from bluetooth_mesh import Element
+from bluetooth_mesh.messages import AccessMessage
 from bluetooth_mesh.messages.config import GATTNamespaceDescriptor
 from bluetooth_mesh.messages.generic.onoff import GenericOnOffOpcode
 from bluetooth_mesh.test.fixtures import *  # pylint: disable=W0614, W0401
@@ -72,7 +73,8 @@ def element(model_mocks):
     return mock_element
 
 
-def test_message_received(element, source, app_index, status_encoded, status_parsed):
+def test_message_received(element, source, app_index, status_encoded):
+    status_parsed = AccessMessage.parse(status_encoded)
     element.message_received(source, app_index, False, status_encoded)
     MockModel.INSTANCES[0].message_received.assert_called_once_with(
         source, app_index, False, status_parsed
@@ -84,9 +86,8 @@ def test_other_opcode_message_received(element, source, app_index, get_encoded):
     MockModel.INSTANCES[0].message_received.assert_not_called()
 
 
-def test_dev_message_received(
-    element, source, net_index, status_encoded, status_parsed
-):
+def test_dev_message_received(element, source, net_index, status_encoded):
+    status_parsed = AccessMessage.parse(status_encoded)
     element.dev_key_message_received(source, True, net_index, status_encoded)
     MockModel.INSTANCES[0].dev_key_message_received.assert_called_once_with(
         source, True, net_index, status_parsed

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,9 @@ setup(
         tools=[
             'prompt-toolkit==2.0.10',
         ],
+        capnp=[
+            'pycapnp',
+        ],
     ),
     entry_points=dict(
         console_scripts=[

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,9 @@ setenv =
     PYTEST_ADDOPTS = --cov
 commands = python setup.py test
 
+[testenv:py37]
+extras = capnp
+
 [testenv:black]
 skip_install = true
 deps = black


### PR DESCRIPTION
- [x] Replace `"opcode" / Const...` in vendor models with `SwitchStruct`
- [x] Make sure the conversion works both ways - parsing and building
- [x] Expand tests to cover messages supported by the remote access api
- [x] Check that `BitListAdapter` converts properly
- [x] Fix `SwitchStruct` compilation
- [x] Fix `NamedSelect` compilation

Note that `SwitchStruct` and `NamedSelect` rename fields in runtime, so they can't be compiled using default generator. To maintain reasonable performance, generated code needed adjusting.