### PR TITLE
messages.util: change DefaultCountValidator 'Unknown' value to float max

### DIFF
--- a/bluetooth_mesh/messages/test/test_battery.py
+++ b/bluetooth_mesh/messages/test/test_battery.py
@@ -19,6 +19,8 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 #
+import sys
+
 import pytest
 
 from bluetooth_mesh.messages.generic.battery import *
@@ -51,9 +53,9 @@ valid = [
         b'\x82\x24\xff\xbb\xaa\x00\xff\xff\xff\xdb',
         GenericBatteryOpcode.GENERIC_BATTERY_STATUS,
         dict(
-            battery_level=None,
+            battery_level=float(sys.float_info.max),
             time_to_discharge=0xaabb,
-            time_to_charge=None,
+            time_to_charge=float(sys.float_info.max),
             flags=dict(
                 battery_presence_flags=GenericBatteryFlagsPresence.BATTERY_PRESENCE_UNKNOWN,
                 battery_indicator_flags=GenericBatteryFlagsIndicator.BATTERY_CHARGE_GOOD,

--- a/bluetooth_mesh/messages/test/test_sensor.py
+++ b/bluetooth_mesh/messages/test/test_sensor.py
@@ -19,6 +19,7 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 #
+import sys
 from datetime import datetime
 
 import pytest
@@ -259,7 +260,7 @@ valid_properties = [
         dict(sensor_property_id=PropertyID.TOTAL_DEVICE_POWER_ON_TIME,
              sensor_setting_property_id=PropertyID.TOTAL_DEVICE_POWER_ON_TIME,
              total_device_power_on_time=dict(
-                 hours=None)),
+                 hours=float(sys.float_info.max))),
         id="TimeHour24_unknown"),
     pytest.param(
         b'\x59\x55\x00\x55\x00\x1a\x27\x00',
@@ -287,7 +288,7 @@ valid_properties = [
         dict(sensor_property_id=PropertyID.TOTAL_DEVICE_POWER_ON_CYCLES,
              sensor_setting_property_id=PropertyID.TOTAL_DEVICE_POWER_ON_CYCLES,
              total_device_power_on_cycles=dict(
-                 count=None)),
+                 count=float(sys.float_info.max))),
         id="Count24_unknown"),
     pytest.param(
         b'\x59\x68\x00\x68\x00\x05\x00',

--- a/bluetooth_mesh/messages/util.py
+++ b/bluetooth_mesh/messages/util.py
@@ -24,6 +24,7 @@
 import enum
 import math
 import re
+import sys
 from ipaddress import IPv4Address
 
 from construct import (
@@ -38,6 +39,7 @@ from construct import (
     Enum,
     ExprValidator,
     Float32b,
+    Float64b,
     Int8ub,
     Int16ub,
     Int24ub,
@@ -265,7 +267,7 @@ class Opcode(Construct):
 
 
 class DefaultCountValidator(Adapter):
-    _subcon = Float32b
+    _subcon = Float64b
 
     def __init__(self, subcon, rounding=None, resolution=1.0):
         super().__init__(subcon)
@@ -274,7 +276,7 @@ class DefaultCountValidator(Adapter):
 
     def _decode(self, obj, content, path):
         if obj == (256 ** self.subcon.length) - 1:
-            return None
+            return float(sys.float_info.max)
         else:
             return (
                 round(obj * self.resolution, self.rounding)
@@ -283,7 +285,7 @@ class DefaultCountValidator(Adapter):
             )
 
     def _encode(self, obj, content, path):
-        if obj is None:
+        if obj == float(sys.float_info.max):
             return (256 ** self.subcon.length) - 1
         else:
             return round(obj / self.resolution)


### PR DESCRIPTION
Messages which are "adapted" to be a float during `binary -> JSON` conversion (by the `construct`) have `None` value for `not known` values (logical value). This causes that the conversion from `JSON -> CapNProto` is impossible. This PR changes value `None` to the `float max` to fix conversion.