### PR TITLE
Installation instruction is wrong

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Installation
 
 You can install "python-bluetooth-mesh" via `pip`_ from `PyPI`_::
 
-    $ pip install python-bluetooth-mesh
+    $ pip install bluetooth-mesh
 
 
 Contributing


### PR DESCRIPTION
Instructions on PyPi say: pip install bluetooth-mesh