### PR TITLE
SP-9178: fix handling "unknown values" by the DefaultCountValidator

### DIFF
--- a/bluetooth_mesh/messages/properties.py
+++ b/bluetooth_mesh/messages/properties.py
@@ -301,7 +301,7 @@ VoltageStatistics = Struct(
 )
 
 RelativeValueInAVoltageRange = Struct(
-    "relative_value" / DefaultCountValidator(Int8ul, rounding=1, resolution=0.5),
+    "relative_value" / DefaultCountValidator(Int8ul, rounding=1, resolution=0.5, unknown_value=False),
     "minimum_voltage" / DefaultCountValidator(Int16ul, resolution=1/64),
     "maximum_voltage" / DefaultCountValidator(Int16ul, resolution=1/64),
 )
@@ -372,7 +372,7 @@ TemperatureStatistics = Struct(
 )
 
 RelativeValueInATemperatureRange = Struct(
-    "relative_value" / DefaultCountValidator(Int8ul, rounding=1, resolution=0.5),
+    "relative_value" / DefaultCountValidator(Int8ul, rounding=1, resolution=0.5, unknown_value=False),
     "minimum_temperature" / DefaultCountValidator(Int16sl, rounding=2, resolution=0.01),
     "maximum_temperature" / DefaultCountValidator(Int16sl, rounding=2, resolution=0.01)
 )
@@ -405,13 +405,13 @@ LuminousEfficacy = Struct(
 )
 
 Illuminance = Struct(
-    "illuminance" / DefaultCountValidator(Int24ul, rounding=2, resolution=0.01)
+    "illuminance" / DefaultCountValidator(Int24ul, rounding=2, resolution=0.01, unknown_value=False)
 )
 
 RelativeValueInAnIlluminanceRange = Struct(
-    "relative_value" / DefaultCountValidator(Int8ul, rounding=1, resolution=0.5),
-    "minimum_illuminance" / DefaultCountValidator(Int24ul, rounding=2, resolution=0.01),
-    "maximum_illuminance" / DefaultCountValidator(Int24ul, rounding=2, resolution=0.01)
+    "relative_value" / DefaultCountValidator(Int8ul, rounding=1, resolution=0.5, unknown_value=False),
+    "minimum_illuminance" / DefaultCountValidator(Int24ul, rounding=2, resolution=0.01, unknown_value=False),
+    "maximum_illuminance" / DefaultCountValidator(Int24ul, rounding=2, resolution=0.01, unknown_value=False)
 )
 
 PerceivedLightness = Struct(
@@ -439,11 +439,11 @@ Coefficient = Struct(
 
 # chromaticity
 ChromaticityTolerance = Struct(
-    "chromaticity_tolerance" / DefaultCountValidator(Int8sl, rounding=4, resolution=0.0001)
+    "chromaticity_tolerance" / DefaultCountValidator(Int8sl, rounding=4, resolution=0.0001, unknown_value=False)
 )
 
 ChromaticDistanceFromPlanckian = Struct(
-    "distance_from_planckian" / DefaultCountValidator(Int16sl, rounding=5, resolution=0.00001)
+    "distance_from_planckian" / DefaultCountValidator(Int16sl, rounding=5, resolution=0.00001, unknown_value=False)
 )
 
 CorrelatedColorTemperature = Struct(
@@ -451,12 +451,12 @@ CorrelatedColorTemperature = Struct(
 )
 
 ChromaticityCoordinates = Struct(
-    "chromaticity_x_coordinate" / DefaultCountValidator(Int16ul, resolution=1/0xffff),
-    "chromaticity_y_coordinate" / DefaultCountValidator(Int16ul, resolution=1/0xffff)
+    "chromaticity_x_coordinate" / DefaultCountValidator(Int16ul, resolution=1/0xffff, unknown_value=False),
+    "chromaticity_y_coordinate" / DefaultCountValidator(Int16ul, resolution=1/0xffff, unknown_value=False)
 )
 
 ColorRenderingIndex = Struct(
-    "color_rendering_index" / DefaultCountValidator(Int8sl)
+    "color_rendering_index" / DefaultCountValidator(Int8sl, unknown_value=False)
 )
 
 
@@ -490,9 +490,9 @@ EventStatistics = Struct(
 )
 
 RelativeRuntimeInAGenericLevelRange = Struct(
-    "relative_value" / DefaultCountValidator(Int8ul, rounding=1, resolution=0.5),
-    "minimum_generic_level" / DefaultCountValidator(Int16ul),
-    "maximum_generic_level" / DefaultCountValidator(Int16ul),
+    "relative_value" / DefaultCountValidator(Int8ul, rounding=1, resolution=0.5, unknown_value=False),
+    "minimum_generic_level" / DefaultCountValidator(Int16ul, unknown_value=False),
+    "maximum_generic_level" / DefaultCountValidator(Int16ul, unknown_value=False),
 )
 
 PropertyDict = {

--- a/bluetooth_mesh/messages/util.py
+++ b/bluetooth_mesh/messages/util.py
@@ -269,13 +269,14 @@ class Opcode(Construct):
 class DefaultCountValidator(Adapter):
     _subcon = Float64b
 
-    def __init__(self, subcon, rounding=None, resolution=1.0):
+    def __init__(self, subcon, rounding=None, resolution=1.0, unknown_value=True):
         super().__init__(subcon)
         self.rounding = rounding
         self.resolution = resolution
+        self.unknown_value = unknown_value
 
     def _decode(self, obj, content, path):
-        if obj == (256 ** self.subcon.length) - 1:
+        if self.unknown_value and obj == (256 ** self.subcon.length) - 1:
             return float(sys.float_info.max)
         else:
             return (
@@ -285,7 +286,7 @@ class DefaultCountValidator(Adapter):
             )
 
     def _encode(self, obj, content, path):
-        if obj == float(sys.float_info.max):
+        if self.unknown_value and obj == float(sys.float_info.max):
             return (256 ** self.subcon.length) - 1
         else:
             return round(obj / self.resolution)


### PR DESCRIPTION
This patch fixes handling "unkown values" of the properties. Previous
implementation based on bad assumption that all properties have unknown
value (the last value in the range). This patch provides ability to define
if property has "unknown value" and set it value.