### PR TITLE
SP-9189: fix broken CapNProto messages

### DIFF
--- a/bluetooth_mesh/messages/capnproto_generator.py
+++ b/bluetooth_mesh/messages/capnproto_generator.py
@@ -33,6 +33,7 @@ from construct import (
     Restreamed,
     Select,
     StopIf,
+    StringEncoded,
     Struct,
     Switch,
     Transformed,
@@ -131,6 +132,9 @@ def convert(
             many=many,
         )
 
+    elif isinstance(con, StringEncoded):
+        visitor.field(con, field_name, struct_name)
+
     elif isinstance(con, (GreedyRange, Array)):
         convert(
             con.subcon,
@@ -206,8 +210,11 @@ class Visitor:
             d="Float64",
         )
 
-        if isinstance(con, Bytes) or con is GreedyBytes:
-            return f"Data"
+        if isinstance(con, StringEncoded):
+            return "Text"
+
+        elif isinstance(con, Bytes) or con is GreedyBytes:
+            return "Data"
 
         elif isinstance(con, FormatField):
             return FORMAT_FIELD_TYPES[con.fmtstr[1:]]

--- a/bluetooth_mesh/messages/silvair/debug.py
+++ b/bluetooth_mesh/messages/silvair/debug.py
@@ -41,9 +41,9 @@ from construct import (
     this,
 )
 
-from bluetooth_mesh.messages.util import DictAdapter, EnumAdapter
+from bluetooth_mesh.messages.util import EnumAdapter
 from bluetooth_mesh.messages.util import EnumSwitch as Switch
-from bluetooth_mesh.messages.util import Opcode, SwitchStruct
+from bluetooth_mesh.messages.util import NamedSelect, Opcode, SwitchStruct
 
 
 class DebugOpcode(IntEnum):
@@ -133,15 +133,11 @@ SystemStatsGet = Struct()
 SystemStat = Struct(
     "name" / PaddedString(8, "utf8"),
     "high_water_mark" / Int16ul,
-    "rfu" / Padding(4),
+    "_rfu" / Padding(4)
 )
 
 SystemStatsStatus = Struct(
-    "stats" / DictAdapter(
-        GreedyRange(SystemStat),
-        key=this.name,
-        value=this.high_water_mark
-    )
+    "stats" / GreedyRange(SystemStat)
 )
 
 LastMallocFaultGet = Struct()
@@ -198,7 +194,7 @@ ArapSize8 = Struct(
 
 ArapListSizeGet = Struct()
 
-ArapListSizeStatus = Select(
+ArapListSizeStatus = NamedSelect(
     new=ArapSize16,
     old=ArapSize8,
 )
@@ -218,11 +214,7 @@ ArapNode = ByteSwapped(
 ArapListContentStatus = Struct(
     "current_page" / Int8ul,
     "last_page" / Int8ul,
-    "nodes" / DictAdapter(
-        GreedyRange(ArapNode),
-        key=this.address,
-        value=[this.ivi, this.sequence]
-    )
+    "nodes" / GreedyRange(ArapNode)
 )
 
 DebugParams = SwitchStruct(

--- a/bluetooth_mesh/messages/silvair/network_diagnostic_server.py
+++ b/bluetooth_mesh/messages/silvair/network_diagnostic_server.py
@@ -45,8 +45,6 @@ from bluetooth_mesh.messages.util import EnumAdapter
 from bluetooth_mesh.messages.util import EnumSwitch as Switch
 from bluetooth_mesh.messages.util import NamedSelect, Opcode, SwitchStruct
 
-MAX_RECORD_COUNT = 32
-
 
 class NetworkDiagnosticServerOpcode(IntEnum):
     SILVAIR_NDS = 0xFC3601
@@ -55,7 +53,7 @@ class NetworkDiagnosticServerOpcode(IntEnum):
 class NetworkDiagnosticServerSubOpcode(IntEnum):
     SUBSCRIPTION_GET = 0x00
     SUBSCRIPTION_SET = 0x01
-    SUBSCRIPTION_SET_UNACK = 0x02
+    SUBSCRIPTION_SET_UNACKNOWLEDGED = 0x02
     SUBSCRIPTION_STATUS = 0x03
     RADIO_STAT_GET = 0x04
     RADIO_STAT_SET = 0x05
@@ -112,20 +110,20 @@ NetworkDiagnosticServerSubscriptionSet = Struct(
 NetworkDiagnosticServerSubscriptionStatus = Struct(
     "destination" / UnicastUnassignedGroupAddress,
     "period" / Int16ul,
-    "max_record_count" / Const(MAX_RECORD_COUNT, Int8ul),
+    "max_record_count" / Int8ul,
     "record" / GreedyRange(RegistryRecord)
 )
 
 NetworkDiagnosticServerRadioStatGet = Struct()
 
-NetworkDiagnosticServerParams = Struct(
+NetworkDiagnosticServerParams = SwitchStruct(
     "subopcode" / EnumAdapter(Int8ul, NetworkDiagnosticServerSubOpcode),
     "payload" / Switch(
         this.subopcode,
         {
             NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_GET: NetworkDiagnosticServerSubscriptionGet,
             NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_SET: NetworkDiagnosticServerSubscriptionSet,
-            NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_SET_UNACK: NetworkDiagnosticServerSubscriptionSet,
+            NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_SET_UNACKNOWLEDGED: NetworkDiagnosticServerSubscriptionSet,
             NetworkDiagnosticServerSubOpcode.SUBSCRIPTION_STATUS: NetworkDiagnosticServerSubscriptionStatus,
             NetworkDiagnosticServerSubOpcode.RADIO_STAT_GET: NetworkDiagnosticServerRadioStatGet
         }

--- a/bluetooth_mesh/messages/silvair/test/test_debug.py
+++ b/bluetooth_mesh/messages/silvair/test/test_debug.py
@@ -163,17 +163,17 @@ valid = [
         b'HEAP\x00\x00\x00\x00\xa8I\x00\x00\x00\x00',
         DebugSubOpcode.SYSTEM_STATS_STATUS,
         {
-            "stats": {
-                'KERNEL': 520,
-                'BLE': 1288,
-                'SNV': 200,
-                'APP': 436,
-                'RX Task': 484,
-                'MESH': 1032,
-                'Tmr Svc': 496,
-                'IDLE': 228,
-                'HEAP': 18856,
-            }
+            "stats": [
+                {"name": u'KERNEL', "high_water_mark": 520},
+                {"name": u'BLE', "high_water_mark": 1288},
+                {"name": u'SNV', "high_water_mark": 200},
+                {"name": u'APP', "high_water_mark": 436},
+                {"name": u'RX Task', "high_water_mark": 484},
+                {"name": u'MESH', "high_water_mark": 1032},
+                {"name": u'Tmr Svc', "high_water_mark": 496},
+                {"name": u'IDLE', "high_water_mark": 228},
+                {"name": u'HEAP', "high_water_mark": 18856},
+            ]
         },
         id='SystemStatsStatus (long)'
     ),
@@ -184,9 +184,11 @@ valid = [
         b'IDLE\x00\x00\x00\x00\xf4\x00\x00\x00\x00\x00',
         DebugSubOpcode.SYSTEM_STATS_STATUS,
         {
-            "stats": {
-                'HEAP': 19080, 'Tmr Svc': 552, 'IDLE': 244,
-            }
+            "stats": [
+                {"name": u'HEAP', "high_water_mark": 19080},
+                {"name": u'Tmr Svc', "high_water_mark": 552},
+                {"name": u'IDLE', "high_water_mark": 244},
+            ]
         },
         id='SystemStatsStatus (short)'
     ),
@@ -196,9 +198,9 @@ valid = [
         {
             'current_page': 0,
             'last_page': 0,
-            'nodes': {
-                0x0080: {"ivi": True, "sequence": 0x58},
-            }
+            'nodes': [
+                {"ivi": True, "sequence": 0x58, "address": 0x0080},
+            ]
         },
         id='ArapContent (1 node)'
     ),
@@ -208,10 +210,10 @@ valid = [
         {
             'current_page': 0,
             'last_page': 0,
-            'nodes': {
-                0x0007: {"ivi": False, "sequence": 0x20c70},
-                0x0080: {"ivi": False, "sequence": 0x58},
-            }
+            'nodes': [
+                {"ivi": False, "sequence": 0x20c70, "address": 0x0007},
+                {"ivi": False, "sequence": 0x58, "address": 0x0080},
+            ]
         },
         id='ArapContent (2 nodes)'
     ),

--- a/bluetooth_mesh/messages/test/test_capnproto.py
+++ b/bluetooth_mesh/messages/test/test_capnproto.py
@@ -39,6 +39,71 @@ if sys.version_info >= (3, 7):
     from bluetooth_mesh.messages.capnproto import generate
 
 valid = [
+    # debug
+    bytes.fromhex("f5360100"),  # RSSI_THRESHOLD_GET
+    bytes.fromhex("f5360101f0"),  # RSSI_THRESHOLD_SET
+    bytes.fromhex("f5360102f0"),  # RSSI_THRESHOLD_STATUS
+    bytes.fromhex("f5360103ff"),  # RADIO_TEST
+    bytes.fromhex("f5360104"),  # TIMESLOT_TX_POWER_GET
+    bytes.fromhex("f536010500"),  # TIMESLOT_TX_POWER_SET
+    bytes.fromhex("f5360105ff"),  # TIMESLOT_TX_POWER_SET
+    bytes.fromhex("f536010600"),  # TIMESLOT_TX_POWER_STATUS
+    bytes.fromhex("f5360106ff"),  # TIMESLOT_TX_POWER_STATUS
+    bytes.fromhex("f5360107"),  # SOFTDEVICE_TX_POWER_GET
+    bytes.fromhex("f536010800"),  # SOFTDEVICE_TX_POWER_SET
+    bytes.fromhex("f5360108ff"),  # SOFTDEVICE_TX_POWER_SET
+    bytes.fromhex("f536010900"),  # SOFTDEVICE_TX_POWER_STATUS
+    bytes.fromhex("f5360109ff"),  # SOFTDEVICE_TX_POWER_STATUS
+    bytes.fromhex("f536010a"),  # UPTIME_GET
+    bytes.fromhex("f536010b00000000"),  # UPTIME_STATUS
+    bytes.fromhex("f536010bffffffff"),  # UPTIME_STATUS
+    bytes.fromhex("f536010c"),  # LAST_SW_FAULT_GET
+    bytes.fromhex("f536010d"),  # LAST_SW_FAULT_CLEAR
+    bytes.fromhex("f536010e00000000616263"),  # LAST_SW_FAULT_STATUS
+    bytes.fromhex("f536010f"),  # SYSTEM_STATS_GET
+    bytes.fromhex("f5360110"),  # SYSTEM_STATS_STATUS
+    bytes.fromhex("f53601106162636465666768000000000000"),
+    bytes.fromhex("f53601106162636400000000ffff00000000"),
+    bytes.fromhex("f5360111"),  # LAST_MALLOC_FAULT_GET
+    bytes.fromhex("f5360112"),  # LAST_MALLOC_FAULT_CLEAR
+    bytes.fromhex("f536011300000000616263"),  # LAST_MALLOC_FAULT_STATUS
+    bytes.fromhex("f5360114"),  # LAST_FDS_FAULT_GET
+    bytes.fromhex("f5360115"),  # LAST_FDS_FAULT_CLEAR
+    bytes.fromhex("f536011600000000616263"),  # LAST_FDS_FAULT_STATUS
+    bytes.fromhex("f5360117"),  # BYTES_BEFORE_GARBAGE_COLLECTOR_GET
+    bytes.fromhex("f53601180000"),  # BYTES_BEFORE_GARBAGE_COLLECTOR_STATUS
+    bytes.fromhex("f53601181234"),  # BYTES_BEFORE_GARBAGE_COLLECTOR_STATUS
+    bytes.fromhex("f5360118ffff"),  # BYTES_BEFORE_GARBAGE_COLLECTOR_STATUS
+    bytes.fromhex("f5360119"),  # PROVISIONED_APP_VERSION_GET
+    bytes.fromhex("f536011a0000"),  # PROVISIONED_APP_VERSION_STATUS
+    bytes.fromhex("f536011a1234"),  # PROVISIONED_APP_VERSION_STATUS
+    bytes.fromhex("f536011affff"),  # PROVISIONED_APP_VERSION_STATUS
+    bytes.fromhex("f536011b"),  # FULL_FIRMWARE_VERSION_GET
+    bytes.fromhex("f536011c61626364"),  # FULL_FIRMWARE_VERSION_STATUS
+    bytes.fromhex("f536011d"),  # IV_INDEX_GET
+    bytes.fromhex("f536011e00000000"),  # IV_INDEX_STATUS
+    bytes.fromhex("f536011e12345678"),  # IV_INDEX_STATUS
+    bytes.fromhex("f536011effffffff"),  # IV_INDEX_STATUS
+    bytes.fromhex("f536011f"),  # GARBAGE_COLLECTOR_COUNTER_GET
+    bytes.fromhex("f53601200000"),  # GARBAGE_COLLECTOR_COUNTER_STATUS
+    bytes.fromhex("f53601201234"),  # GARBAGE_COLLECTOR_COUNTER_STATUS
+    bytes.fromhex("f5360120ffff"),  # GARBAGE_COLLECTOR_COUNTER_STATUS
+    bytes.fromhex("f5360121"),  # ARAP_LIST_SIZE_GET
+    bytes.fromhex("f53601220000"),  # ARAP_LIST_SIZE_STATUS
+    bytes.fromhex("f53601221234"),  # ARAP_LIST_SIZE_STATUS
+    bytes.fromhex("f5360122ffff"),  # ARAP_LIST_SIZE_STATUS
+    bytes.fromhex("f536012200000000"),  # ARAP_LIST_SIZE_STATUS
+    bytes.fromhex("f536012212345678"),  # ARAP_LIST_SIZE_STATUS
+    bytes.fromhex("f5360122ffffffff"),  # ARAP_LIST_SIZE_STATUS
+    bytes.fromhex("f536012300"),  # ARAP_LIST_CONTENT_GET
+    bytes.fromhex("f536012312"),  # ARAP_LIST_CONTENT_GET
+    bytes.fromhex("f5360123ff"),  # ARAP_LIST_CONTENT_GET
+    bytes.fromhex("f53601240000"),  # ARAP_LIST_CONTENT_STATUS
+    bytes.fromhex("f536012400000000000000"),  # ARAP_LIST_CONTENT_STATUS
+    bytes.fromhex("f53601240000ffffffffff"),  # ARAP_LIST_CONTENT_STATUS
+    bytes.fromhex(
+        "f53601240000ffffffffff00000000001234561234"
+    ),  # ARAP_LIST_CONTENT_STATUS
     # config
     bytes.fromhex("02003601CE00FECAEFBE0BB000000000"),
     bytes.fromhex("8002000b00010000012100"),
@@ -46,8 +111,15 @@ valid = [
     # ctl
     bytes.fromhex("826522223333ff323c"),
     # nds
-    bytes.fromhex("FD3601011234AAAA82031000"),
-    bytes.fromhex("FD3601011234AAAA820310000300"),
+    bytes.fromhex("fd360100"),  # PUBLICATION_GET
+    bytes.fromhex("fd3601011234aaaa82031000"),  # PUBLICATION_SET
+    bytes.fromhex("fd3601011234aaaa820310000300"),  # PUBLICATION_SET
+    bytes.fromhex("fd3601011234aaaa82031000"),  # PUBLICATION_SET
+    bytes.fromhex("fd3601021234aaaa820310000300"),  # PUBLICATION_STATUS
+    bytes.fromhex("fc360100"),  # SUBSCRIPTION_GET
+    bytes.fromhex("fc3601010123aaaa"),  # SUBSCRIPTION_SET
+    bytes.fromhex("fc3601020123aaaa"),  # SUBSCRIPTION_SET_UNACKNOWLEDGED
+    bytes.fromhex("fc3601031234aaaa20012300110101"),  # SUBSCRIPTION_STATUS
     # sensor
     bytes.fromhex("8230"),
     bytes.fromhex("82300400"),

--- a/bluetooth_mesh/messages/util.py
+++ b/bluetooth_mesh/messages/util.py
@@ -308,32 +308,6 @@ class IpAddressAdapter(Adapter):
         return bytes(int(i) for i in obj.split("."))
 
 
-class DictAdapter(Adapter):
-    def __init__(self, subcon, key, value):
-        super().__init__(subcon)
-        self.key = key
-        self.value = value
-
-    def _decode(self, obj, context, path):
-        if isinstance(self.value, (list, tuple)):
-            return {
-                self.key(i): {v.__getfield__(): v(i) for v in self.value} for i in obj
-            }
-
-        return {self.key(i): self.value(i) for i in obj}
-
-    def _encode(self, obj, context, path):
-        key_name = self.key.__getfield__()
-
-        if isinstance(self.value, (list, tuple)):
-            for k, v in obj.items():
-                yield {key_name: k, **v}
-        else:
-            value_name = self.value.__getfield__()
-            for k, v in obj.items():
-                yield {key_name: k, value_name: v}
-
-
 class AliasedContainer(Container):
     ALIAS = None
     ORIGINAL = None


### PR DESCRIPTION
This patch fixes broken CapNProto messages in the models: Debug and
NetworkDiagnosticServer.