### PR TITLE
Correct value in provisioning error code

### DIFF
--- a/bluetooth_mesh/provisioning.py
+++ b/bluetooth_mesh/provisioning.py
@@ -117,7 +117,7 @@ class ProvisioningErrorCode(enum.IntEnum):
     OUT_OF_RESOURCES = 5
     DECRYPTION_FAILED = 6
     UNEXPECTED_ERROR = 7
-    CANNOT_ASSIGN_ADDRESS = 8
+    CANNOT_ASSIGN_ADDRESSES = 8
 
 
 class LinkCloseReason(enum.IntEnum):

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.rst", "r") as f:
 # fmt: off
 setup(
     name='bluetooth-mesh',
-    version='0.7.15',
+    version='0.7.16',
     author_email='michal.lowas-rzechonek@silvair.com',
     description=(
         'Bluetooth mesh for Python'


### PR DESCRIPTION
According to the Mesh Profile spec, the value in Provisioning Error Codes is `Cannot Assign Addresses` rather than `... Address`