### PR TITLE
Provisioning pdu building parsing not in provisioning transaction

### DIFF
--- a/bluetooth_mesh/mesh.py
+++ b/bluetooth_mesh/mesh.py
@@ -43,7 +43,6 @@ from bluetooth_mesh.provisioning import (
     GenericProvisioning,
     GenericProvisioningPDUType,
     ProvisioningBearerControl,
-    ProvisioningPDU,
     ProvisioningPDUType,
 )
 
@@ -528,14 +527,12 @@ CRC_CALCULATOR = CrcCalculator(configuration=MESH_CRC)
 
 class ProvisioningTransaction:
     @staticmethod
-    def pack(payload):
+    def pack(pdu):
         """
-        Given a dictionary that matches ProvisioningPDU, generate transaction
+        Given bytes with already built ProvisioningPDU, generate transaction
         a sequence of GenericProvisioning packets, starting with
         TransactionStart, followed by zero or more TransactionContinuations
         """
-        pdu = ProvisioningPDU.build(payload)
-
         segments = [pdu[0:20]]
         if len(pdu) > 20:
             segments += [pdu[0 + i : 23 + i] for i in range(20, len(pdu), 23)]
@@ -566,7 +563,7 @@ class ProvisioningTransaction:
     def unpack(segments):
         """
         Given a sequence of GenericProvisioning packets, reassemble a
-        ProvisioningPDU, parse it and return as dictionary.
+        ProvisioningPDU and return as bytes that may be parsed.
 
         Note: segments must belong to a single transaction, but they don't need
         to be in-order, may contain duplicates and may be interleaved with
@@ -599,4 +596,4 @@ class ProvisioningTransaction:
                 f"Transaction checksum is invalid, expected {start.frame_check:02x}, got {fcs:02x}",
             )
 
-        return ProvisioningPDU.parse(pdu)
+        return pdu

--- a/bluetooth_mesh/test/test_provisioning.py
+++ b/bluetooth_mesh/test/test_provisioning.py
@@ -328,13 +328,13 @@ valid = [
 
 @pytest.mark.parametrize("encoded,decoded", valid)
 def test_transaction_pack(encoded, decoded):
-    result = list(ProvisioningTransaction.pack(payload=decoded))
+    result = list(ProvisioningTransaction.pack(pdu=ProvisioningPDU.build(decoded)))
     assert result == encoded
 
 
 @pytest.mark.parametrize("encoded,decoded", valid)
 def test_unpack_generic(encoded, decoded):
-    result = ProvisioningTransaction.unpack(segments=encoded)
+    result = ProvisioningPDU.parse(ProvisioningTransaction.unpack(segments=encoded))
     assert result == decoded
 
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.rst", "r") as f:
 # fmt: off
 setup(
     name='bluetooth-mesh',
-    version='0.7.17',
+    version='0.7.18',
     author_email='michal.lowas-rzechonek@silvair.com',
     description=(
         'Bluetooth mesh for Python'


### PR DESCRIPTION
As I need the possibility to sendinvalid provisioning data (e.g. RFU values in Provisioning Start PDU) to node(s), I would like to exclude building/parsing ProvisioningPDU from methods of ProvisioningTransaction - this will enable injecting ProvisioningPDUs with invalid values in their payloads, otherwise not achievable by construct structures defined here.