### PR TITLE
Fix return type of request_prov_data for dbus-next

### DIFF
--- a/bluetooth_mesh/interfaces.py
+++ b/bluetooth_mesh/interfaces.py
@@ -261,7 +261,7 @@ class ProvisionerInterface(ServiceInterface):
 
     @method(name="RequestProvData")
     def request_prov_data(self, count: "y") -> "qq":
-        return self.application.request_prov_data(count)
+        return list(self.application.request_prov_data(count))
 
     @method(name="AddNodeComplete")
     def add_node_complete(self, uuid: "ay", unicast: "q", count: "y"):


### PR DESCRIPTION
dbus-next methods are supposed to return lists, not tuples. I'd rather dbus-next allowed that... but that's beside the point.

This patch fixes request_prov_data() in interfaces.py to add a missing conversion so that a type error is not thrown on return when marshalling the return type.