### PR TITLE
remove support for TX power subopcodes in Debug model

### DIFF
--- a/bluetooth_mesh/messages/silvair/debug.py
+++ b/bluetooth_mesh/messages/silvair/debug.py
@@ -55,12 +55,6 @@ class DebugSubOpcode(IntEnum):
     RSSI_THRESHOLD_SET = 0x01
     RSSI_THRESHOLD_STATUS = 0x02
     RADIO_TEST = 0x03
-    TIMESLOT_TX_POWER_GET = 0x04
-    TIMESLOT_TX_POWER_SET = 0x05
-    TIMESLOT_TX_POWER_STATUS = 0x06
-    SOFTDEVICE_TX_POWER_GET = 0x07
-    SOFTDEVICE_TX_POWER_SET = 0x08
-    SOFTDEVICE_TX_POWER_STATUS = 0x09
     UPTIME_GET = 0x0A
     UPTIME_STATUS = 0x0B
     LAST_SW_FAULT_GET = 0x0C
@@ -99,18 +93,6 @@ RssiThreshold = Struct(
 
 RadioTest = Struct(
     "packet_counter" / Int8ul
-)
-
-TimeslotTxPowerGet = Struct()
-
-TimeslotTxPowerStatus = Struct(
-    "tx_power" / Int8ul
-)
-
-SoftdeviceTxPowerGet = Struct()
-
-SoftdeviceTxPowerStatus = Struct(
-    "tx_power" / Int8ul
 )
 
 UptimeGet = Struct()
@@ -226,12 +208,6 @@ DebugParams = SwitchStruct(
             DebugSubOpcode.RSSI_THRESHOLD_SET: RssiThreshold,
             DebugSubOpcode.RSSI_THRESHOLD_STATUS: RssiThreshold,
             DebugSubOpcode.RADIO_TEST: RadioTest,
-            DebugSubOpcode.TIMESLOT_TX_POWER_GET: TimeslotTxPowerGet,
-            DebugSubOpcode.TIMESLOT_TX_POWER_SET: TimeslotTxPowerStatus,
-            DebugSubOpcode.TIMESLOT_TX_POWER_STATUS: TimeslotTxPowerStatus,
-            DebugSubOpcode.SOFTDEVICE_TX_POWER_GET: SoftdeviceTxPowerGet,
-            DebugSubOpcode.SOFTDEVICE_TX_POWER_SET: SoftdeviceTxPowerStatus,
-            DebugSubOpcode.SOFTDEVICE_TX_POWER_STATUS: SoftdeviceTxPowerStatus,
             DebugSubOpcode.UPTIME_GET: UptimeGet,
             DebugSubOpcode.UPTIME_STATUS: UptimeStatus,
             DebugSubOpcode.LAST_SW_FAULT_GET: LastSwFaultGet,

--- a/bluetooth_mesh/messages/silvair/test/test_debug.py
+++ b/bluetooth_mesh/messages/silvair/test/test_debug.py
@@ -26,8 +26,6 @@ from bluetooth_mesh.messages.silvair.debug import DebugParams, DebugSubOpcode
 # fmt: off
 valid = [
     pytest.param(b'\x00', DebugSubOpcode.RSSI_THRESHOLD_GET, {}, id="RssiThresholdGet"),
-    pytest.param(b'\x04', DebugSubOpcode.TIMESLOT_TX_POWER_GET, {}, id="TimeslotTxPowerGet"),
-    pytest.param(b'\x07', DebugSubOpcode.SOFTDEVICE_TX_POWER_GET, {}, id="SoftDeviceTxPowerGet"),
     pytest.param(b'\x0a', DebugSubOpcode.UPTIME_GET, {}, id="UptimeGet"),
     pytest.param(b'\x0c', DebugSubOpcode.LAST_SW_FAULT_GET, {}, id="LastSwFaultGet"),
     pytest.param(b'\x0f', DebugSubOpcode.SYSTEM_STATS_GET, {}, id="SystemStatsGet"),
@@ -65,30 +63,6 @@ valid = [
         DebugSubOpcode.RADIO_TEST,
         {'packet_counter': 0x01},
         id="RadioTest"
-    ),
-    pytest.param(
-        b'\x05\x02',
-        DebugSubOpcode.TIMESLOT_TX_POWER_SET,
-        {'tx_power': 0x02},
-        id="TimeslotTxPowerSet"
-    ),
-    pytest.param(
-        b'\x06\x04',
-        DebugSubOpcode.TIMESLOT_TX_POWER_STATUS,
-        {'tx_power': 0x04},
-        id="TimeslotTxPowerStatus"
-    ),
-    pytest.param(
-        b'\x08\x02',
-        DebugSubOpcode.SOFTDEVICE_TX_POWER_SET,
-        {'tx_power': 0x02},
-        id="SoftDeviceTxPowerSet"
-    ),
-    pytest.param(
-        b'\x09\x04',
-        DebugSubOpcode.SOFTDEVICE_TX_POWER_STATUS,
-        {'tx_power': 0x04},
-        id="SoftDeviceTxPowerStatus"
     ),
     pytest.param(
         b'\x0b\xa2\xd0\x02\x00',

--- a/bluetooth_mesh/messages/test/test_capnproto.py
+++ b/bluetooth_mesh/messages/test/test_capnproto.py
@@ -44,16 +44,6 @@ valid = [
     bytes.fromhex("f5360101f0"),  # RSSI_THRESHOLD_SET
     bytes.fromhex("f5360102f0"),  # RSSI_THRESHOLD_STATUS
     bytes.fromhex("f5360103ff"),  # RADIO_TEST
-    bytes.fromhex("f5360104"),  # TIMESLOT_TX_POWER_GET
-    bytes.fromhex("f536010500"),  # TIMESLOT_TX_POWER_SET
-    bytes.fromhex("f5360105ff"),  # TIMESLOT_TX_POWER_SET
-    bytes.fromhex("f536010600"),  # TIMESLOT_TX_POWER_STATUS
-    bytes.fromhex("f5360106ff"),  # TIMESLOT_TX_POWER_STATUS
-    bytes.fromhex("f5360107"),  # SOFTDEVICE_TX_POWER_GET
-    bytes.fromhex("f536010800"),  # SOFTDEVICE_TX_POWER_SET
-    bytes.fromhex("f5360108ff"),  # SOFTDEVICE_TX_POWER_SET
-    bytes.fromhex("f536010900"),  # SOFTDEVICE_TX_POWER_STATUS
-    bytes.fromhex("f5360109ff"),  # SOFTDEVICE_TX_POWER_STATUS
     bytes.fromhex("f536010a"),  # UPTIME_GET
     bytes.fromhex("f536010b00000000"),  # UPTIME_STATUS
     bytes.fromhex("f536010bffffffff"),  # UPTIME_STATUS


### PR DESCRIPTION
TIMESLOT_TX_POWER and SOFTDEVICE_TX_POWER states in Debug models are no longer supported in the firmware.
