### PR TITLE
Revert "Bump cryptography module"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     install_requires=[
         'bitstring>=3.1.5,<4.0.0',
         'construct>=2.9.45,<2.9.46',
-        'cryptography==39.0.1',
+        'cryptography>=2.3.1,<3.4',
         'crc==0.3.0',
         'dbus-next>=0.2.1',
         'ecdsa==0.15',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.rst", "r") as f:
 # fmt: off
 setup(
     name='bluetooth-mesh',
-    version='0.8.5',
+    version='0.8.4',
     author_email='michal.lowas-rzechonek@silvair.com',
     description=(
         'Bluetooth mesh for Python'


### PR DESCRIPTION
Reverts SilvairGit/python-bluetooth-mesh#176