### PR TITLE
Fix provisioning transaction

### DIFF
--- a/bluetooth_mesh/mesh.py
+++ b/bluetooth_mesh/mesh.py
@@ -591,7 +591,7 @@ class ProvisioningTransaction:
         pdu = start.data + b"".join(continuation.data for continuation in continuations)
 
         fcs = CRC_CALCULATOR.calculate_checksum(pdu)
-        if fcs != start.frame_check:
+        if start.total_length != len(pdu) or fcs != start.frame_check:
             raise ValidationError(
                 f"Transaction checksum is invalid, expected {start.frame_check:02x}, got {fcs:02x}",
             )


### PR DESCRIPTION
Fix Unpacking Provisioning Transaction.
It can happen that fcs( 8bits) calculated from the  whole provisoning pdu is the same in value  as 
fcs calculated from first fragment of provisioning pdu.
So having only  first fragmen of multifragment  transaction and trying to unpack it will succeed but data will not be complete. 
Verification if all transactions data were received should solve the issue.